### PR TITLE
feat: BaseEntity Soft Delete 구현

### DIFF
--- a/src/main/java/com/example/unbox_be/domain/common/BaseEntity.java
+++ b/src/main/java/com/example/unbox_be/domain/common/BaseEntity.java
@@ -33,18 +33,19 @@ public abstract class BaseEntity {
     @Column(name = "updated_by")
     private String updatedBy;
 
-//    // 삭제는 JPA Auditing 기본 기능에 없으므로, 로직에서 직접 처리
-//    @Column(name = "deleted_at")
-//    private LocalDateTime deletedAt;
-//
-//    @Column(name = "deleted_by")
-//    private String deletedBy;
-//
-//    /**
-//     * 소프트 삭제 처리를 위한 편의 메서드
-//     */
-//    public void delete(String deletedBy) {
-//        this.deletedAt = LocalDateTime.now();
-//        this.deletedBy = deletedBy;
-//    }
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "deleted_by")
+    private String deletedBy;
+
+    public void softDelete(String deletedBy) {
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = deletedBy;
+    }
+
+    public void undoDelete() {
+        this.deletedAt = null;
+        this.deletedBy = null;
+    }
 }


### PR DESCRIPTION
## 📋 이슈 번호
- Issue: Closes #26 

## 🛠️ 작업 내용
- [x] BaseEntity 수정: JPA Auditing이 지원하지 않는 deletedAt, deletedBy 필드 직접 추가
- [x] 편의 메서드 구현: 엔티티 상태를 변경하여 삭제 처리하는 softDelete(), undoDelete() 메서드 작성
- [x] @SQLRestriction 도입: Hibernate 6.3+ (Spring Boot 3.2+)부터 Deprecated된 @Where 대신 권장되는 @SQLRestriction 방식 적용

## 📸 테스트 결과 (스크린샷/로그)

## 💬 리뷰 포인트
- BaseEntity에 추가된 필드와 softDelete 메서드 로직을 확인해 주세요.
- 중요: 앞으로 데이터를 삭제할 때는 repository.delete() 대신 **entity.softDelete()**를 사용해야 합니다. (Service 계층 구현 시 참고)
- 각 도메인 엔티티에 @SQLRestriction("deleted_at IS NULL") 어노테이션이 누락되지 않도록 주의가 필요합니다.

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일/빌드 되나요?
- [x] 로컬 환경에서 테스트를 완료했나요?
- [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
- [x] 브랜치 전략(Git Flow Lite)을 준수했나요? (develop -> feat/26-implement-soft-delete)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 소프트 삭제 기능 활성화: 항목을 삭제할 때 삭제 시간과 삭제한 사용자 정보가 자동으로 기록됩니다. 데이터 감사 추적성이 향상되었으며, 필요에 따라 삭제된 항목을 복구할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->