### PR TITLE
chore: 테스트 환경을 위한 H2 DB 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,8 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    // Test
+    // H2 + Test
+    testImplementation 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/test/java/com/example/unbox_be/UnboxBeApplicationTests.java
+++ b/src/test/java/com/example/unbox_be/UnboxBeApplicationTests.java
@@ -2,7 +2,9 @@ package com.example.unbox_be;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class UnboxBeApplicationTests {
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,28 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  datasource:
+    url: jdbc:h2:mem:unbox;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+jwt:
+  secret: 5Z+j99jYMA+kKsdq0zjEVSQsAeLEUTyzsdGZ5pas5eQ=
+  access-token-validity-ms: 10000
+  refresh-token-validity-ms: 10000
+
+#payment:
+#  client-key: secretsecretsecret
+#  secret-key: secretsecretsecret
+#  confirmUrl: secretsecretsecret


### PR DESCRIPTION
## 📋 이슈 번호
- Issue: Closes (이슈 번호 X)

## 🛠️ 작업 내용
- [x] 테스트 환경 전용 H2 Database 의존성(runtimeOnly) 추가
- [x] application-test.yml 설정 파일 작성 및 H2 연동 구성
- [x] 운영 DB(PostgreSQL)와의 호환성을 위해 MODE=PostgreSQL 설정 적용
- [x] 테스트 격리를 위해 ddl-auto: create-drop 전략 설정

## 📸 테스트 결과 (스크린샷/로그)
<img width="1461" height="230" alt="image" src="https://github.com/user-attachments/assets/6f68371f-90dd-4c07-bed5-a3dbbab3e91f" />

## 💬 리뷰 포인트
- application-test.yml의 DB URL과 JPA 설정들이 적절한지 확인 부탁드립니다.
- 운영 환경인 PostgreSQL과 문법 차이를 줄이기 위해 호환 모드를 적용했습니다.

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일/빌드 되나요?
- [x] 로컬 환경에서 테스트를 완료했나요?
- [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
- [x] 브랜치 전략(Git Flow Lite)을 준수했나요? (develop -> feat/...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 테스트 환경을 위한 인메모리 데이터베이스 지원 추가
  * 테스트 프로필 활성화 및 관련 설정 구성 완료
  * SQL 로깅 및 데이터베이스 초기화 설정 포함

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->