### PR TITLE
feat : 판매자 주문 취소 기능 구현

### DIFF
--- a/src/main/java/com/example/unbox_be/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/unbox_be/domain/order/controller/OrderController.java
@@ -81,4 +81,17 @@ public class OrderController {
 
         return ResponseEntity.ok(ApiResponse.success(detailDto));
     }
+
+    /**
+     * 주문 취소 (판매자)
+     */
+    @PatchMapping("/{orderId}/cancel")
+    public ResponseEntity<ApiResponse<OrderDetailResponseDto>> cancelOrder(
+            @PathVariable UUID orderId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        OrderDetailResponseDto responseDto = orderService.cancelOrder(orderId, userDetails.getUsername());
+
+        return ResponseEntity.ok(ApiResponse.success(responseDto));
+    }
 }

--- a/src/main/java/com/example/unbox_be/domain/order/dto/OrderDetailResponseDto.java
+++ b/src/main/java/com/example/unbox_be/domain/order/dto/OrderDetailResponseDto.java
@@ -21,6 +21,7 @@ public class OrderDetailResponseDto {
     private BigDecimal price;
     private OrderStatus status;
     private LocalDateTime createdAt;
+    private LocalDateTime cancelledAt;
 
     // 2. 배송 정보 (개인정보 보호 대상)
     private String receiverName;

--- a/src/main/java/com/example/unbox_be/domain/order/mapper/OrderMapper.java
+++ b/src/main/java/com/example/unbox_be/domain/order/mapper/OrderMapper.java
@@ -52,6 +52,7 @@ public class OrderMapper {
                 .price(order.getPrice())
                 .status(order.getStatus())
                 .createdAt(order.getCreatedAt())
+                .cancelledAt(order.getCancelledAt())
                 // 배송 정보
                 .receiverName(order.getReceiverName())
                 .receiverPhone(order.getReceiverPhone())

--- a/src/main/java/com/example/unbox_be/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/unbox_be/global/error/exception/ErrorCode.java
@@ -37,7 +37,8 @@ public enum ErrorCode {
     INVALID_BID_PRICE(HttpStatus.BAD_REQUEST, "입찰 가격이 유효하지 않습니다."),
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문 내역을 찾을 수 없습니다."),
     PRICE_MISMATCH(HttpStatus.BAD_REQUEST, "주문 가격이 실제 판매 가격과 일치하지 않습니다."),
-    SELLING_BID_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 판매자가 판매 중인 상품이 아닙니다.");
+    SELLING_BID_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 판매자가 판매 중인 상품이 아닙니다."),
+    ORDER_CANNOT_BE_CANCELLED(HttpStatus.BAD_REQUEST, "이미 배송 중이거나 완료된 주문은 취소할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 📋 이슈 번호
- Issue: Closes #56

## 🛠️ 작업 내용
- [x] **판매자 주문 취소 API 구현** (`PATCH /api/orders/{orderId}/cancel`)
    - 물리적 데이터 삭제(Soft Delete)가 아닌, **주문 상태를 `CANCELLED`로 변경**하는 로직 구현
    - 취소 이력 관리를 위해 `Order` 엔티티에 `cancelledAt` (취소 일시) 필드 추가
- [x] **비즈니스 로직 및 예외 처리 강화**
    - **권한 검증:** 요청자가 해당 주문의 **판매자(Seller)** 인지 확인 (아닐 경우 `403 Forbidden`)
    - **상태 검증:** 이미 배송 시작(`SHIPPED`)되었거나 완료된 주문은 취소 불가 처리 (`400 Bad Request`)
- [x] **DTO 및 Mapper 수정**
    - 주문 상세 조회 응답(`OrderDetailResponseDto`)에 `cancelledAt` 필드 추가 및 매핑 로직 반영

## 📸 테스트 결과 (스크린샷/로그)
<img width="897" height="702" alt="image" src="https://github.com/user-attachments/assets/42f79660-f448-4d78-839c-4193fc7fc232" />

## 💬 리뷰 포인트
- 주문 취소를 데이터 삭제(`deletedAt`)가 아닌 상태 변경(`status`, `cancelledAt`)으로 처리했습니다. 추후 정산이나 CS 처리를 위해 이력을 남기는 방향으로 설계했는데 적절한지 검토 부탁드립니다.
- `Order` 엔티티의 `cancel()` 메서드 내에서 상태 변경 검증 로직을 수행하도록 도메인 주도적으로 설계했습니다.

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일/빌드 되나요?
- [x] 로컬 환경에서 테스트를 완료했나요?
- [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
- [x] 브랜치 전략(Git Flow Lite)을 준수했나요? (develop -> feat/...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 주문 취소 기능 추가
  * 판매자는 판매한 주문을 취소할 수 있습니다
  * 배송 중이거나 완료된 주문은 취소할 수 없습니다
  * 주문 취소 시 취소 일시가 자동으로 기록됩니다

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->