### PR TITLE
feat: 구매자 주문 취소 기능 구현 및 검증 로직 확장

### DIFF
--- a/src/main/java/com/example/unbox_be/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/unbox_be/domain/order/service/OrderService.java
@@ -148,19 +148,15 @@ public class OrderService {
      */
     private void validateCancelRequest(Order order, User user) {
         // 1. 기본 접근 권한 체크
-        // -> 여기서 구매자도 아니고 판매자도 아니면 ACCESS_DENIED 예외 발생
         validateOrderAccess(order, user);
 
         // 2. 구매자인 경우 상태 체크
-        boolean isBuyer = order.getBuyer().getId().equals(user.getId());
-
-        if (isBuyer) {
+        if (order.getBuyer().getId().equals(user.getId())) {
             // 구매자는 오직 'PENDING_SHIPMENT(배송 대기)' 상태일 때만 취소 가능
             if (order.getStatus() != OrderStatus.PENDING_SHIPMENT) {
                 throw new CustomException(ErrorCode.ORDER_CANNOT_BE_CANCELLED);
             }
         }
-
-        // (판매자는 Entity의 cancel() 메서드 내에서 SHIPPED/DELIVERED 여부만 체크하면 되므로 별도 로직 불필요)
+        // 판매자는 Order.cancel() 메서드에서 배송 상태 검증
     }
 }


### PR DESCRIPTION
## 📋 이슈 번호
- Issue: Closes #59

## 🛠️ 작업 내용
- [x] **구매자 주문 취소 권한 추가**
    - 기존 판매자 전용이었던 취소 기능을 구매자(Buyer)도 사용할 수 있도록 확장
    - `OrderService.cancelOrder` 내 권한 검증 로직 수정
- [x] **구매자 전용 취소 정책 적용**
    - 구매자는 오직 **발송 대기(PENDING_SHIPMENT)** 상태에서만 취소 가능하도록 제한 로직 추가
    - 배송이 시작된 경우 취소 불가 예외 처리 (`ORDER_CANNOT_BE_CANCELLED`)
- [x] **검증 로직 리팩토링**
    - `validateCancelRequest` 메서드를 신설하여 기본 접근 권한(`validateOrderAccess`)과 취소 가능 상태 체크를 분리하여 관리

## 📸 테스트 결과 (스크린샷/로그)
- 스크린샷 없음

## 💬 리뷰 포인트
- `validateCancelRequest`에서 기존 `validateOrderAccess`를 호출하여 코드 중복을 제거했습니다. 
- 판매자는 배송 준비 중에도 취소가 필요한 경우가 있어 구매자에게만 상태 제약을 엄격하게 적용했는데, 판매자의 취소 가능 범위에 대해서도 의견 부탁드립니다.

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일/빌드 되나요?
- [x] 로컬 환경에서 테스트를 완료했나요?
- [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
- [x] 브랜치 전략(Git Flow Lite)을 준수했나요? (develop -> feat/...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 구매자도 주문 취소 기능을 사용할 수 있게 되었습니다. (기존: 판매자 전용)
  * 구매자는 배송 대기 상태(PENDING_SHIPMENT)인 주문만 취소할 수 있습니다.

* **문서**
  * 주문 취소 설명이 판매자/구매자 공용으로 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->