### PR TITLE
feat: wishlist관련 API 구현

### DIFF
--- a/src/main/java/com/example/unbox_be/domain/trade/repository/SellingBidRepository.java
+++ b/src/main/java/com/example/unbox_be/domain/trade/repository/SellingBidRepository.java
@@ -24,5 +24,5 @@ public interface SellingBidRepository extends JpaRepository<SellingBid, UUID> {
     Slice<SellingBid> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
     @EntityGraph(attributePaths = {"productOption", "productOption.product"})
-    Optional<SellingBid> findWithDetailsBySellingId(UUID sellingId);
+    Optional<SellingBid> findBySellingId(UUID sellingId);
 }

--- a/src/main/java/com/example/unbox_be/domain/trade/service/SellingBidService.java
+++ b/src/main/java/com/example/unbox_be/domain/trade/service/SellingBidService.java
@@ -3,7 +3,6 @@ package com.example.unbox_be.domain.trade.service;
 import com.example.unbox_be.domain.product.entity.ProductOption;
 import com.example.unbox_be.domain.product.repository.ProductOptionRepository;
 import com.example.unbox_be.domain.trade.dto.request.SellingBidRequestDto;
-import com.example.unbox_be.domain.trade.dto.request.UpdateSellingStatusRequestDto;
 import com.example.unbox_be.domain.trade.dto.response.SellingBidResponseDto;
 import com.example.unbox_be.domain.trade.entity.SellingBid;
 import com.example.unbox_be.domain.trade.entity.SellingStatus;
@@ -96,7 +95,7 @@ public class SellingBidService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        SellingBid sellingBid = sellingBidRepository.findWithDetailsBySellingId(sellingId) // 이걸로 변경!
+        SellingBid sellingBid = sellingBidRepository.findBySellingId(sellingId) // 이걸로 변경!
                 .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
         SellingBidResponseDto response = sellingBidMapper.toResponseDto(sellingBid);
 
@@ -137,7 +136,9 @@ public class SellingBidService {
             SellingBidResponseDto dto = sellingBidMapper.toResponseDto(bid);
 
             ProductOption option= bid.getProductOption();
-
+            if (option == null) {
+                return dto;
+            }
             return dto.toBuilder()
                     .size(option.getOption())
                     .product(SellingBidResponseDto.ProductInfo.builder()

--- a/src/main/java/com/example/unbox_be/domain/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/example/unbox_be/domain/wishlist/controller/WishlistController.java
@@ -1,0 +1,56 @@
+package com.example.unbox_be.domain.wishlist.controller;
+
+import com.example.unbox_be.domain.user.entity.User;
+import com.example.unbox_be.domain.wishlist.dto.request.WishlistRequestDTO;
+import com.example.unbox_be.domain.wishlist.dto.response.WishlistResponseDTO;
+import com.example.unbox_be.domain.wishlist.service.WishlistService;
+import com.example.unbox_be.global.security.auth.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/wishlist")
+@RequiredArgsConstructor
+public class WishlistController {
+
+    private final WishlistService wishlistService;
+
+    // 1. 위시리스트 추가 (찜하기)
+    @PostMapping
+    public ResponseEntity<Void> addWishlist(
+            @AuthenticationPrincipal CustomUserDetails userDetails, // 로그인된 유저 정보 자동 주입
+            @RequestBody WishlistRequestDTO requestDTO
+    ) {
+        wishlistService.addWishlist(userDetails.getUsername(), requestDTO.getOptionId());
+        return ResponseEntity.ok().build();
+    }
+
+    // 2. 내 위시리스트 목록 조회
+    @GetMapping
+    public ResponseEntity<List<WishlistResponseDTO>> getMyWishlist(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(hidden = true) @PageableDefault(size = 3, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        List<WishlistResponseDTO> response = wishlistService.getMyWishlist(userDetails.getUsername(), pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    // 3. 위시리스트 삭제 (선택 사항)
+    @DeleteMapping("/{wishlistId}")
+    public ResponseEntity<Void> removeWishlist(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable UUID wishlistId
+    ) {
+        wishlistService.removeWishlist(userDetails.getUsername(), wishlistId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/unbox_be/domain/wishlist/dto/request/WishlistRequestDTO.java
+++ b/src/main/java/com/example/unbox_be/domain/wishlist/dto/request/WishlistRequestDTO.java
@@ -1,0 +1,15 @@
+package com.example.unbox_be.domain.wishlist.dto.request;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WishlistRequestDTO {
+    private UUID optionId;
+}

--- a/src/main/java/com/example/unbox_be/domain/wishlist/dto/response/WishlistResponseDTO.java
+++ b/src/main/java/com/example/unbox_be/domain/wishlist/dto/response/WishlistResponseDTO.java
@@ -1,0 +1,35 @@
+package com.example.unbox_be.domain.wishlist.dto.response;
+
+import com.example.unbox_be.domain.product.entity.Product;
+import com.example.unbox_be.domain.product.entity.ProductOption;
+import com.example.unbox_be.domain.wishlist.entity.Wishlist;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class WishlistResponseDTO {
+    private UUID wishlistId;     // 위시리스트 항목 고유 ID
+    private UUID productId;      // 상품 ID
+    private String productName;  // 상품명
+    private String optionName;   // 옵션명 (예: 255, Black 등)
+    private String imageUrl;     // 상품 이미지 (필요시)
+
+    // Entity를 DTO로 변환하는 정적 팩토리 메서드
+    public static WishlistResponseDTO from(Wishlist wishlist) {
+        ProductOption option = wishlist.getProductOption();
+        Product product = option.getProduct();
+
+        return WishlistResponseDTO.builder()
+                .wishlistId(wishlist.getId())
+                .productId(product.getId())
+                .productName(product.getName())
+                .optionName(option.getOption())
+                .imageUrl(product.getImageUrl()) // 이미지 필드가 있다면 추가
+                .build();
+    }
+}

--- a/src/main/java/com/example/unbox_be/domain/wishlist/entity/Wishlist.java
+++ b/src/main/java/com/example/unbox_be/domain/wishlist/entity/Wishlist.java
@@ -1,0 +1,39 @@
+package com.example.unbox_be.domain.wishlist.entity;
+
+import com.example.unbox_be.domain.common.BaseEntity;
+import com.example.unbox_be.domain.product.entity.ProductOption;
+import com.example.unbox_be.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_wishlists")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA를 위한 기본 생성자
+public class Wishlist extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "wishlist_id", updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_id", nullable = false)
+    private ProductOption productOption;
+
+    @Builder
+    public Wishlist(User user, ProductOption productOption) {
+        this.user = user;
+        this.productOption = productOption;
+    }
+}

--- a/src/main/java/com/example/unbox_be/domain/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/example/unbox_be/domain/wishlist/repository/WishlistRepository.java
@@ -1,0 +1,20 @@
+package com.example.unbox_be.domain.wishlist.repository;
+
+import com.example.unbox_be.domain.product.entity.ProductOption;
+import com.example.unbox_be.domain.user.entity.User;
+import com.example.unbox_be.domain.wishlist.entity.Wishlist;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface WishlistRepository extends JpaRepository<Wishlist, UUID> {
+    // 특정 유저가 특정 상품 옵션을 이미 찜했는지 확인 (중복 방지용)
+    boolean existsByUserAndProductOption(User user, ProductOption productOption);
+
+    // 내 위시리스트 목록 조회
+    @EntityGraph(attributePaths = {"productOption", "productOption.product"})
+    Slice<Wishlist> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);
+}

--- a/src/main/java/com/example/unbox_be/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/com/example/unbox_be/domain/wishlist/service/WishlistService.java
@@ -1,0 +1,82 @@
+package com.example.unbox_be.domain.wishlist.service;
+
+import com.example.unbox_be.domain.product.entity.ProductOption;
+import com.example.unbox_be.domain.product.repository.ProductOptionRepository;
+import com.example.unbox_be.domain.user.entity.User;
+import com.example.unbox_be.domain.user.repository.UserRepository;
+import com.example.unbox_be.domain.wishlist.dto.response.WishlistResponseDTO;
+import com.example.unbox_be.domain.wishlist.entity.Wishlist;
+import com.example.unbox_be.domain.wishlist.repository.WishlistRepository;
+import com.example.unbox_be.global.error.exception.CustomException;
+import com.example.unbox_be.global.error.exception.ErrorCode;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class WishlistService {
+
+    private final WishlistRepository wishlistRepository;
+    private final ProductOptionRepository productOptionRepository;
+    private final UserRepository userRepository; // 유저 조회를 위해 추가
+
+    // 1. 위시리스트 추가
+    @Transactional
+    public void addWishlist(String email, UUID optionId) {
+        // 이메일로 영속 상태의 유저 엔티티 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        ProductOption option = productOptionRepository.findById(optionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_OPTION_NOT_FOUND));
+
+        // 중복 체크 (영속화된 user 객체 사용)
+        if (wishlistRepository.existsByUserAndProductOption(user, option)) {
+            throw new CustomException(ErrorCode.WISHLIST_ALREADY_EXISTS);
+        }
+
+        Wishlist wishlist = Wishlist.builder()
+                .user(user)
+                .productOption(option)
+                .build();
+
+        wishlistRepository.save(wishlist);
+    }
+
+    // 2. 내 위시리스트 목록 조회
+    @Transactional(readOnly = true)
+    public List<WishlistResponseDTO> getMyWishlist(String email, Pageable pageable) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 해당 유저의 위시리스트 조회
+        Slice<Wishlist> wishlistSlice = wishlistRepository.findByUserOrderByCreatedAtDesc(user, pageable);
+
+        return wishlistSlice.getContent().stream()
+                .map(WishlistResponseDTO::from)
+                .toList();
+    }
+
+    // 3. 위시리스트 삭제
+    @Transactional
+    public void removeWishlist(String email, UUID wishlistId) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Wishlist wishlist = wishlistRepository.findById(wishlistId)
+                .orElseThrow(() -> new CustomException(ErrorCode.WISHLIST_NOT_FOUND));
+
+        // 보안 검증: 삭제하려는 항목의 주인이 현재 로그인한 유저인지 확인
+        if (!wishlist.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        wishlistRepository.delete(wishlist);
+    }
+}

--- a/src/main/java/com/example/unbox_be/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/unbox_be/global/error/exception/ErrorCode.java
@@ -57,13 +57,16 @@ public enum ErrorCode {
     // 브랜드
     BRAND_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 브랜드입니다."),
     BRAND_NOT_FOUND(HttpStatus.NOT_FOUND, "브랜드 정보를 찾을 수 없습니다."),
-    
+
     // 주문
     ORDER_CANNOT_BE_CANCELLED(HttpStatus.BAD_REQUEST, "이미 배송 중이거나 완료된 주문은 취소할 수 없습니다."),
     TRACKING_NUMBER_REQUIRED(HttpStatus.BAD_REQUEST, "배송 시작 시 운송장 번호는 필수입니다."),
     INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 주문 상태입니다."),
-    INVALID_ORDER_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "유효하지 않은 주문 상태 변경입니다.");
+    INVALID_ORDER_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "유효하지 않은 주문 상태 변경입니다."),
 
+    //위시리스트
+    WISHLIST_ALREADY_EXISTS(HttpStatus.BAD_REQUEST,"이미 찜 목록에 존재하는 상품입니다."),
+    WISHLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "찜 목록에서 찾을 수 없습니다.");
     private final HttpStatus status;
     private final String message;
 }

--- a/src/test/java/com/example/unbox_be/domain/trade/service/SellingBidServiceTest.java
+++ b/src/test/java/com/example/unbox_be/domain/trade/service/SellingBidServiceTest.java
@@ -110,7 +110,7 @@ class SellingBidServiceTest {
         given(userRepository.findByEmail(anyString())).willReturn(Optional.of(user));
 
         // 어떤 UUID가 들어와도 sellingBid를 반환하도록 설정 (findById와 커스텀 메서드 둘 다 대응)
-        given(sellingBidRepository.findWithDetailsBySellingId(any(UUID.class))) // 서비스와 이름 맞춤
+        given(sellingBidRepository.findBySellingId(any(UUID.class))) // 서비스와 이름 맞춤
                 .willReturn(Optional.of(sellingBid));
 
         given(sellingBidMapper.toResponseDto(any(SellingBid.class))).willReturn(mockDto);


### PR DESCRIPTION
찜추가, 찜삭제, 찜목록 조회 기능 추가
Close #72

## 📋 이슈 번호
- Issue: Closes #

## 🛠️ 작업 내용
- [ ] wishlist관련 기능 추가
- [ ] 찜 추가, 찜 삭제, 찜 목록 조회 기능 구현

## 📸 테스트 결과 (스크린샷/로그)
💬 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일/빌드 되나요?
- [ ] 로컬 환경에서 테스트를 완료했나요?
- [ ] 불필요한 주석이나 디버깅 코드는 제거했나요?
- [ ] 브랜치 전략(Git Flow Lite)을 준수했나요? (develop -> feat/...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 찜 목록 관리 기능 추가: 관심 상품을 찜 목록에 추가하고 삭제할 수 있습니다
* 찜 목록 페이지네이션: 사용자의 찜 목록을 최신순으로 정렬하여 페이지별로 조회할 수 있습니다
* 중복 상품 방지: 이미 찜 목록에 있는 상품은 중복으로 추가되지 않습니다

## 버그 수정
* 판매 입찰 정보 조회 시 안정성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->