### PR TITLE
fix: Admin 로그인 시 JWT 토큰 생성 에러 수정

### DIFF
--- a/src/main/java/com/example/unbox_be/domain/auth/dto/response/UserTokenResponseDto.java
+++ b/src/main/java/com/example/unbox_be/domain/auth/dto/response/UserTokenResponseDto.java
@@ -13,4 +13,5 @@ public class UserTokenResponseDto {
 
     private String accessToken;  // 액세스 토큰
     private String refreshToken; // 리프레시 토큰
+    private String role;         // 유저 권한 (ROLE_USER, ROLE_MASTER, etc.)
 }

--- a/src/main/java/com/example/unbox_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/unbox_be/global/config/SecurityConfig.java
@@ -8,7 +8,6 @@ import com.example.unbox_be.global.security.token.RefreshTokenRedisRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -26,7 +25,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
-import com.example.unbox_be.global.security.exception.CustomAuthenticationEntryPoint;
+import com.example.unbox_be.global.error.exception.CustomAuthenticationEntryPoint;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 

--- a/src/main/java/com/example/unbox_be/global/init/GlobalDataInitializer.java
+++ b/src/main/java/com/example/unbox_be/global/init/GlobalDataInitializer.java
@@ -1,0 +1,101 @@
+package com.example.unbox_be.global.init;
+
+import com.example.unbox_be.domain.admin.common.entity.Admin;
+import com.example.unbox_be.domain.admin.common.entity.AdminRole;
+import com.example.unbox_be.domain.admin.common.repository.AdminRepository;
+import com.example.unbox_be.domain.product.entity.Brand;
+import com.example.unbox_be.domain.product.entity.Category;
+import com.example.unbox_be.domain.product.entity.Product;
+import com.example.unbox_be.domain.product.repository.BrandRepository;
+import com.example.unbox_be.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile("!prod") // 운영(prod) 환경이 아닐 때만 동작
+public class GlobalDataInitializer implements ApplicationRunner {
+
+    private final AdminRepository adminRepository;
+    private final BrandRepository brandRepository;
+    private final ProductRepository productRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        // 1. Master 관리자 계정 생성
+        initMasterAdmin();
+
+        // 2. 초기 브랜드 및 상품 데이터 생성 (브랜드가 없을 때만 실행)
+        if (brandRepository.count() == 0) {
+            initBrandsAndProducts();
+        }
+    }
+
+    private void initMasterAdmin() {
+        // 이메일 중복 체크 (이미 존재하면 Skip)
+        if (adminRepository.existsByEmail("master@unbox.com")) {
+            return;
+        }
+
+        // 팩토리 메서드 + 닉네임 정규식(소문자+숫자 4~10자) 준수
+        Admin master = Admin.createAdmin(
+                "master@unbox.com",
+                passwordEncoder.encode("12341234!"), // 암호화 필수
+                "master01",                          // 닉네임 규칙 준수
+                "010-1234-5678",
+                AdminRole.ROLE_MASTER
+        );
+
+        adminRepository.save(master);
+        log.info("=========== [Seed Data] Master Admin Created ===========");
+        log.info("ID: master@unbox.com / PW: 12341234!");
+        log.info("========================================================");
+    }
+
+    private void initBrandsAndProducts() {
+        // 1. 브랜드 생성
+        Brand nike = Brand.createBrand(
+                "Nike",
+                "https://dummyimage.com/200x200/000/fff&text=Nike"
+        );
+
+        Brand adidas = Brand.createBrand(
+                "Adidas",
+                "https://dummyimage.com/200x200/000/fff&text=Adidas"
+        );
+
+        brandRepository.save(nike);
+        brandRepository.save(adidas);
+
+        // 2. 상품 생성 (Category.SHOES 사용)
+        Product jordan1 = Product.createProduct(
+                "Jordan 1 Retro High OG Chicago 2022",
+                "DZ5485-612",
+                Category.SHOES,
+                "https://dummyimage.com/600x600/000/fff&text=Jordan1",
+                nike
+        );
+
+        Product yeezySlide = Product.createProduct(
+                "Adidas Yeezy Slide Bone 2022",
+                "FZ5897",
+                Category.SHOES,
+                "https://dummyimage.com/600x600/000/fff&text=Yeezy",
+                adidas
+        );
+
+        productRepository.save(jordan1);
+        productRepository.save(yeezySlide);
+
+        log.info("=========== [Seed Data] Brand & Product Created ===========");
+    }
+}


### PR DESCRIPTION
## 📋 이슈 번호
* Issue: Closes #89

## 🛠️ 작업 내용

* [x] **개발 환경용 초기 시드 데이터 주입 기능 구현**
* `ApplicationRunner`를 상속받은 `GlobalDataInitializer` 클래스를 구현하여 서버 구동 시 필수 데이터 자동 적재
* 운영 환경 사고 방지를 위해 `@Profile("!prod")` 적용
* **Master 관리자 계정 생성**: ID `master@unbox.com`, `BCrypt` 암호화 적용 및 정규식 기반 닉네임 정책(`master01`) 준수
* **기초 도메인 데이터 생성**: 브랜드(Nike, Adidas) 및 카테고리(SHOES) 기반 초기 상품 데이터 적재
* 데이터 중복 방지를 위한 `existsByEmail`, `count` 체크 로직 포함


* [x] **관리자 로그인 시 JWT 토큰 생성 및 검증 버그 수정**
* `LoginFilter`에서 Admin 로그인 시 `userId`가 아닌 `adminId`를 식별자로 추출하여 JWT Claim에 저장하도록 로직 수정
* `JwtUtil.getUserId()` 호출 시 `null` 값 주입으로 인해 발생하던 `IllegalArgumentException` 해결


## 📸 테스트 결과 (스크린샷/로그)
* 스크린샷 없음

## 💬 리뷰 포인트

* `GlobalDataInitializer`가 엔티티의 정적 팩토리 메서드(`createAdmin`, `createBrand` 등)를 사용하여 도메인 무결성을 지키며 데이터를 생성하는지 확인 부탁드립니다.
* `LoginFilter`에서 `userDetails.isAdmin()` 여부에 따라 `adminId`와 `userId`를 분기 처리하여 추출하는 방식이 적절한지 검토 부탁드립니다.

## ✅ 체크리스트

* [x] 코드가 정상적으로 컴파일/빌드 되나요?
* [x] 로컬 환경에서 테스트를 완료했나요?
* [x] 불필요한 주석이나 디버깅 코드는 제거했나요?
* [x] 브랜치 전략(Git Flow Lite)을 준수했나요? (develop -> feat/89-seed-data)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 인증 토큰 응답에 사용자 역할 정보 추가
  * 애플리케이션 초기 실행 시 기본 데이터 자동 생성

* **Improvements**
  * 사용자 인증 처리 및 로깅 강화

* **Chores**
  * 내부 코드 구조 정리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->