### PR TITLE
fix: OrderRepository 메서드 중복 정의 오류 수정

### DIFF
--- a/src/main/java/com/example/unbox_be/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/unbox_be/domain/order/repository/OrderRepository.java
@@ -19,9 +19,6 @@ public interface OrderRepository extends JpaRepository<Order, UUID> {
     @EntityGraph(attributePaths = {"productOption", "productOption.product", "productOption.product.brand"})
     Page<Order> findAllByBuyerIdAndDeletedAtIsNull(Long buyerId, Pageable pageable);
 
-    // 주문 ID로 단건 조회(삭제 제외)
-    Optional<Order> findByIdAndDeletedAtIsNull(UUID id);
-
     // 주문 상세 조회(삭제 포함)
     @EntityGraph(attributePaths = {"buyer", "seller", "productOption", "productOption.product", "productOption.product.brand"})
     Optional<Order> findWithDetailsById(UUID id);


### PR DESCRIPTION
## 📋 이슈 번호
- Issue: Closes #113 

## 🛠️ 작업 내용
- [x] `OrderRepository` 내 중복 정의된 `findByIdAndDeletedAtIsNull` 메서드 삭제
- [x] `@EntityGraph`가 적용된 메서드를 유지하여 연관 엔티티 페치 조인 보장

## 💬 리뷰 포인트
- 중복된 메서드를 제거하면서 `@EntityGraph`가 붙은 쪽을 살렸습니다. 쿼리가 의도대로 나가는지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **리팩토링**
  * 내부 데이터 접근 계층 정리 및 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->