### PR TITLE
feat: 관리자 사용자 상세 조회 DTO 가입일 필드 추가

### DIFF
--- a/src/main/java/com/example/unbox_be/domain/admin/user/dto/response/AdminUserDetailResponseDto.java
+++ b/src/main/java/com/example/unbox_be/domain/admin/user/dto/response/AdminUserDetailResponseDto.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
@@ -15,5 +16,5 @@ public class AdminUserDetailResponseDto {
     private String email;
     private String nickname;
     private String phone;
-    private java.time.LocalDateTime createdAt;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/unbox_be/domain/admin/user/dto/response/AdminUserListResponseDto.java
+++ b/src/main/java/com/example/unbox_be/domain/admin/user/dto/response/AdminUserListResponseDto.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
@@ -15,5 +16,5 @@ public class AdminUserListResponseDto {
     private String email;
     private String nickname;
     private String phone;
-    private java.time.LocalDateTime createdAt;
+    private LocalDateTime createdAt;
 }


### PR DESCRIPTION
## 📋 이슈 번호
- Issue: Closes #117 

## 🛠️ 작업 내용
- [x] `AdminUserDetailResponseDto` 필드 수정 (가입일 `createdAt` 추가)
- [x] `AdminUserListResponseDto` 등 리스트 조회 DTO에도 동일 필드 적용 확인 (필요 시)

## 💬 리뷰 포인트
- DTO에 필드만 추가했습니다. `UserMapper`나 `AdminUserMapper`가 `mapstruct`를 사용 중이라면 빌드 시 자동으로 매핑 코드가 생성되겠지만, 수동 매핑이라면 Mapper 로직도 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 대시보드의 사용자 목록 및 상세 조회 API 응답에 각 사용자 계정의 생성 일시(createdAt)가 추가되었습니다. 계정 생성 시점을 정확히 확인할 수 있어 사용자 관리와 분석이 개선됩니다.

<sub>✏️ Tip: 검토 설정에서 이 요약을 사용자화할 수 있습니다.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->