### PR TITLE
refactor : 서비스 분리를 위한 최저가 조회 제거

### DIFF
--- a/src/main/java/com/example/unbox_be/common/client/order/dto/OrderForReviewInfoResponse.java
+++ b/src/main/java/com/example/unbox_be/common/client/order/dto/OrderForReviewInfoResponse.java
@@ -1,6 +1,5 @@
 package com.example.unbox_be.common.client.order.dto;
 
-import com.example.unbox_be.order.entity.OrderStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,7 +12,7 @@ public class OrderForReviewInfoResponse {
     private Long buyerId;
     private String buyerNickname;
 
-    private OrderStatus orderStatus;
+    private String orderStatus;
 
     private UUID productId;
     private String productName;

--- a/src/main/java/com/example/unbox_be/order/mapper/OrderClientMapper.java
+++ b/src/main/java/com/example/unbox_be/order/mapper/OrderClientMapper.java
@@ -14,7 +14,7 @@ public interface OrderClientMapper {
 
     @Mapping(target = "buyerId", source = "buyer.id") // USER 분리하면 수정
     @Mapping(target = "buyerNickname", source = "buyer.nickname") // USER 분리하면 수정
-    @Mapping(target = "orderStatus", source = "status")
+    @Mapping(target = "orderStatus", expression = "java(order.getStatus().name())")
     @Mapping(target = "productId", source = "productId")
     @Mapping(target = "productName", source = "productName")
     @Mapping(target = "modelNumber", source = "modelNumber")

--- a/src/main/java/com/example/unbox_be/product/product/application/service/ProductServiceImpl.java
+++ b/src/main/java/com/example/unbox_be/product/product/application/service/ProductServiceImpl.java
@@ -18,8 +18,6 @@ import com.example.unbox_be.product.reviews.dto.response.ReviewListResponseDto;
 import com.example.unbox_be.product.reviews.entity.Review;
 import com.example.unbox_be.product.reviews.mapper.ReviewMapper;
 import com.example.unbox_be.product.reviews.repository.ReviewRepository;
-import com.example.unbox_be.trade.domain.entity.SellingStatus;
-import com.example.unbox_be.trade.domain.repository.SellingBidRepository;
 import com.example.unbox_be.common.client.product.dto.ProductOptionForOrderInfoResponse;
 import com.example.unbox_be.common.client.product.dto.ProductOptionForSellingBidInfoResponse;
 import com.example.unbox_common.error.exception.CustomException;
@@ -31,9 +29,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -44,20 +40,17 @@ public class ProductServiceImpl implements ProductService {
         private final BrandRepository brandRepository;
         private final ProductMapper productMapper;
         private final BrandMapper brandMapper;
-        private final SellingBidRepository sellingBidRepository;
         private final ReviewRepository reviewRepository;
         private final ReviewMapper reviewMapper;
         private final ProductClientMapper productClientMapper;
 
-        // ✅ 상품 목록 조회 (검색 + 페이징)
+        // ✅ 상품 목록 조회 (검색 + 페이징) - 최저가 조회 제거 버전
         public Page<ProductListResponseDto> getProducts(UUID brandId, String category, String keyword, Pageable pageable) {
 
                 // 1️⃣ category 문자열을 Category Enum으로 변환
-                //    - null 또는 빈 문자열이면 필터를 적용하지 않기 위함
                 Category categoryEnum = Category.fromNullable(category);
 
-                // 2️⃣ 브랜드 / 카테고리 / 키워드 조건으로 상품을 페이징 조회
-                //    - deletedAt IS NULL 조건 포함
+                // 2️⃣ 브랜드 / 카테고리 / 키워드 조건으로 상품을 페이징 조회 (deletedAt IS NULL 포함)
                 Page<Product> products = productRepository.findByFiltersAndDeletedAtIsNull(
                         brandId,
                         categoryEnum,
@@ -65,111 +58,31 @@ public class ProductServiceImpl implements ProductService {
                         pageable
                 );
 
-                // 3️⃣ 현재 페이지에 포함된 상품 ID만 추출
-                //    - 이후 최저가 조회 시 전체 상품을 다시 조회하지 않기 위함 (성능 최적화)
-                List<UUID> productIds = products.getContent().stream()
-                        .map(Product::getId)
-                        .toList();
-
-                // 4️⃣ 조회된 상품이 하나도 없으면
-                //    - DB 추가 조회 없이 바로 빈 가격(0)으로 응답
-                if (productIds.isEmpty()) {
-                        return products.map(p -> productMapper.toProductListResponseDto(p, 0));
-                }
-
-                // 5️⃣ 조회된 상품들의 모든 옵션을 한 번에 조회
-                //    - 상품 → 옵션 조회를 개별로 하면 N+1 문제가 발생함
-                List<ProductOption> allOptions = productOptionRepository
-                        .findAllByProductIdInAndDeletedAtIsNull(productIds);
-
-                // 6️⃣ 옵션 ID만 추출
-                //    - 판매 입찰(SellingBid) 최저가 조회에 사용
-                List<UUID> optionIds = allOptions.stream()
-                        .map(ProductOption::getId)
-                        .toList();
-
-                // 7️⃣ 옵션 ID 기준으로 최저가 조회
-                //    - optionId, lowestPrice 형태의 결과를 Map으로 변환
-                //    - 가격이 없으면 0으로 처리
-                Map<UUID, Integer> optionPriceMap = optionIds.isEmpty()
-                        ? Map.of() // 옵션이 없으면 조회하지 않음
-                        : sellingBidRepository.findLowestPricesByProductOptionIds(optionIds)
-                        .stream()
-                        .collect(Collectors.toMap(
-                                row -> (UUID) row[0],                     // optionId
-                                row -> row[1] == null ? 0                 // 가격이 없으면 0
-                                        : ((Number) row[1]).intValue()     // Number → int 변환
-                        ));
-
-                // 8️⃣ 옵션별 가격을 상품별 최저가로 변환
-                //    - 한 상품은 여러 옵션을 가질 수 있으므로 최소값만 선택
-                Map<UUID, Integer> productPriceMap = allOptions.stream()
-                        .collect(Collectors.groupingBy(
-                                opt -> opt.getProduct().getId(),                  // 상품 ID 기준 그룹화
-                                Collectors.mapping(
-                                        opt -> optionPriceMap.getOrDefault(
-                                                opt.getId(), Integer.MAX_VALUE),  // 옵션 가격
-                                        Collectors.minBy(Integer::compareTo)      // 상품 내 최저가 선택
-                                )
-                        ))
-                        .entrySet()
-                        .stream()
-                        .collect(Collectors.toMap(
-                                Map.Entry::getKey,                                // productId
-                                e -> e.getValue().orElse(0) == Integer.MAX_VALUE
-                                        ? 0                                       // 가격이 없으면 0
-                                        : e.getValue().orElse(0)
-                        ));
-
-                // 9️⃣ 상품 + 상품별 최저가를 DTO로 변환하여 최종 응답
-                return products.map(p ->
-                        productMapper.toProductListResponseDto(
-                                p,
-                                productPriceMap.getOrDefault(p.getId(), 0)
-                        )
-                );
+                // 3️⃣ 최저가 조회 로직 제거
+                return products.map(productMapper::toProductListResponseDto);
         }
 
-        // ✅ 상품 상세 조회
+        // ✅ 상품 상세 조회 (최저가 완전 제거)
         public ProductDetailResponseDto getProductDetail(UUID productId) {
                 Product product = productRepository.findByIdAndDeletedAtIsNullWithBrand(productId)
-                                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+                        .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
-                // Get all options for this product, then query lowest prices
-                List<ProductOption> options = productOptionRepository.findAllByProductIdAndDeletedAtIsNull(productId);
-                List<UUID> optionIds = options.stream().map(ProductOption::getId).toList();
-
-                Integer lowestPrice = 0;
-                if (!optionIds.isEmpty()) {
-                        lowestPrice = sellingBidRepository.findLowestPriceByProductOptionIds(optionIds,
-                                        SellingStatus.LIVE);
-                }
-
-                // 조회된 최저가가 없으면 0(또는 null) 처리
-                return productMapper.toProductDetailDto(product, lowestPrice != null ? lowestPrice : 0);
+                return productMapper.toProductDetailDto(product);
         }
 
-        // ✅ 상품 옵션별 최저가 조회
+        // ✅ 상품 옵션 조회 (옵션별 최저가 완전 제거)
         @Override
         public List<ProductOptionListResponseDto> getProductOptions(UUID productId) {
                 if (!productRepository.existsById(productId)) {
                         throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
                 }
 
-                List<ProductOption> options = productOptionRepository.findAllByProductIdAndDeletedAtIsNull(productId);
-                List<UUID> optionIds = options.stream().map(ProductOption::getId).toList();
-
-                Map<UUID, Integer> lowestPriceMap = sellingBidRepository.findLowestPriceByOptionIds(optionIds)
-                                .stream()
-                                .collect(Collectors.toMap(
-                                                row -> (UUID) row[0],
-                                                row -> ((Number) row[1]).intValue()));
+                List<ProductOption> options =
+                        productOptionRepository.findAllByProductIdAndDeletedAtIsNull(productId);
 
                 return options.stream()
-                                .map(option -> productMapper.toProductOptionListDto(
-                                                option,
-                                                lowestPriceMap.getOrDefault(option.getId(), 0)))
-                                .toList();
+                        .map(productMapper::toProductOptionListDto)
+                        .toList();
         }
 
         // ✅ 브랜드 전체 조회

--- a/src/main/java/com/example/unbox_be/product/product/presentation/dto/response/ProductDetailResponseDto.java
+++ b/src/main/java/com/example/unbox_be/product/product/presentation/dto/response/ProductDetailResponseDto.java
@@ -23,7 +23,7 @@ public class ProductDetailResponseDto {
     private UUID brandId;
     private String brandName;
 
-    private Integer lowestPrice;
+//    private Integer lowestPrice;
 
     private Integer reviewCount;
     private Double averageRating;

--- a/src/main/java/com/example/unbox_be/product/product/presentation/dto/response/ProductListResponseDto.java
+++ b/src/main/java/com/example/unbox_be/product/product/presentation/dto/response/ProductListResponseDto.java
@@ -23,6 +23,6 @@ public class ProductListResponseDto {
     private UUID brandId;
     private String brandName;
 
-    private Integer lowestPrice;
+//    private Integer lowestPrice;
 }
 

--- a/src/main/java/com/example/unbox_be/product/product/presentation/dto/response/ProductOptionListResponseDto.java
+++ b/src/main/java/com/example/unbox_be/product/product/presentation/dto/response/ProductOptionListResponseDto.java
@@ -15,5 +15,5 @@ public class ProductOptionListResponseDto {
 
     private UUID  productOptionId;
     private String productOptionName;
-    private Integer lowestPrice;
+//    private Integer lowestPrice;
 }

--- a/src/main/java/com/example/unbox_be/product/product/presentation/mapper/ProductMapper.java
+++ b/src/main/java/com/example/unbox_be/product/product/presentation/mapper/ProductMapper.java
@@ -14,20 +14,7 @@ import org.mapstruct.ReportingPolicy;
 )
 public interface ProductMapper {
 
-    default ProductListResponseDto toProductListDto(Product product, Integer lowestPrice) {
-        return ProductListResponseDto.builder()
-                .productId(product.getId())
-                .productName(product.getName())
-                .modelNumber(product.getModelNumber())
-                .category(product.getCategory())
-                .productImageUrl(product.getImageUrl())
-                .brandId(product.getBrand().getId())
-                .brandName(product.getBrand().getName())
-                .lowestPrice(lowestPrice)
-                .build();
-    }
-
-    default ProductDetailResponseDto toProductDetailDto(Product product, Integer lowestPrice) {
+    default ProductDetailResponseDto toProductDetailDto(Product product) {
 
         // 평균 리뷰 계산
         double avg = 0.0;
@@ -46,26 +33,17 @@ public interface ProductMapper {
                 .brandName(product.getBrand().getName())
                 .reviewCount(product.getReviewCount())
                 .averageRating(avg)
-                .lowestPrice(lowestPrice)
                 .build();
     }
 
-    default ProductOptionListResponseDto toProductOptionListDto(ProductOption option, Integer lowestPrice) {
+    default ProductOptionListResponseDto toProductOptionListDto(ProductOption option) {
         return ProductOptionListResponseDto.builder()
                 .productOptionId(option.getId())
                 .productOptionName(option.getName())
-                .lowestPrice(lowestPrice)
                 .build();
     }
 
-    /* =========================
-       목록 조회 (최저가 포함)
-       ========================= */
-
-    default ProductListResponseDto toProductListResponseDto(
-            Product product,
-            Integer lowestPrice
-    ) {
+    default ProductListResponseDto toProductListResponseDto(Product product) {
         return ProductListResponseDto.builder()
                 .productId(product.getId())
                 .productName(product.getName())
@@ -74,7 +52,6 @@ public interface ProductMapper {
                 .productImageUrl(product.getImageUrl())
                 .brandId(product.getBrand().getId())
                 .brandName(product.getBrand().getName())
-                .lowestPrice(lowestPrice)
                 .build();
     }
 }

--- a/src/main/java/com/example/unbox_be/product/reviews/dto/response/ReviewDetailResponseDto.java
+++ b/src/main/java/com/example/unbox_be/product/reviews/dto/response/ReviewDetailResponseDto.java
@@ -1,6 +1,5 @@
 package com.example.unbox_be.product.reviews.dto.response;
 
-import com.example.unbox_be.order.entity.OrderStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,7 +26,7 @@ public class ReviewDetailResponseDto {
     @Builder
     public static class OrderInfo {
         private UUID orderId;
-        private OrderStatus orderStatus;
+        private String orderStatus;
         private UserInfo buyer;
         private ProductOptionInfo productOption;
     }

--- a/src/main/java/com/example/unbox_be/product/reviews/entity/ReviewProductSnapshot.java
+++ b/src/main/java/com/example/unbox_be/product/reviews/entity/ReviewProductSnapshot.java
@@ -1,6 +1,5 @@
 package com.example.unbox_be.product.reviews.entity;
 
-import com.example.unbox_be.order.entity.OrderStatus;
 import jakarta.persistence.Embeddable;
 import lombok.*;
 
@@ -15,7 +14,7 @@ public class ReviewProductSnapshot {
 
     private Long buyerId;
     private String buyerNickname;
-    private OrderStatus orderStatus;
+    private String orderStatus;
     private UUID productId;
     private String productName;
     private String modelNumber;

--- a/src/main/java/com/example/unbox_be/product/reviews/mapper/ReviewMapper.java
+++ b/src/main/java/com/example/unbox_be/product/reviews/mapper/ReviewMapper.java
@@ -1,13 +1,11 @@
 package com.example.unbox_be.product.reviews.mapper;
 
-import com.example.unbox_be.order.entity.Order;
 import com.example.unbox_be.product.reviews.dto.response.ReviewCreateResponseDto;
 import com.example.unbox_be.product.reviews.dto.response.ReviewDetailResponseDto;
 import com.example.unbox_be.product.reviews.dto.response.ReviewListResponseDto;
 import com.example.unbox_be.product.reviews.dto.response.ReviewUpdateResponseDto;
 import com.example.unbox_be.product.reviews.entity.Review;
 import com.example.unbox_be.product.reviews.entity.ReviewProductSnapshot;
-import com.example.unbox_be.user.user.entity.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;

--- a/src/main/java/com/example/unbox_be/product/reviews/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/unbox_be/product/reviews/service/ReviewServiceImpl.java
@@ -4,7 +4,6 @@ import com.example.unbox_be.common.client.order.dto.OrderForReviewInfoResponse;
 import com.example.unbox_common.error.exception.CustomException;
 import com.example.unbox_common.error.exception.ErrorCode;
 import com.example.unbox_be.order.adapter.OrderClientAdapter;
-import com.example.unbox_be.order.entity.OrderStatus;
 import com.example.unbox_be.product.reviews.dto.request.ReviewCreateRequestDto;
 import com.example.unbox_be.product.reviews.dto.request.ReviewUpdateRequestDto;
 import com.example.unbox_be.product.reviews.dto.response.ReviewCreateResponseDto;
@@ -28,6 +27,8 @@ public class ReviewServiceImpl implements ReviewService {
     private final OrderClientAdapter orderClientAdapter;
     private final ReviewMapper reviewMapper;
 
+    private static final String ORDER_STATUS_COMPLETED = "COMPLETED";
+
     // ✅ 리뷰 생성
     @Override
     @Transactional
@@ -44,7 +45,7 @@ public class ReviewServiceImpl implements ReviewService {
         OrderForReviewInfoResponse orderInfo = orderClientAdapter.getOrderForReview(orderId);
 
         // 3) 주문 상태 검증
-        if (orderInfo.getOrderStatus() != OrderStatus.COMPLETED) {
+        if (!ORDER_STATUS_COMPLETED.equals(orderInfo.getOrderStatus())) {
             throw new CustomException(ErrorCode.ORDER_NOT_COMPLETED);
         }
 

--- a/src/main/java/com/example/unbox_be/trade/application/service/SellingBidService.java
+++ b/src/main/java/com/example/unbox_be/trade/application/service/SellingBidService.java
@@ -41,11 +41,6 @@ public interface SellingBidService {
     Slice<SellingBidListResponseDto> getMySellingBids(Long userId, Pageable pageable);
 
     /**
-     * 판매 입찰 상태 변경 (유저용)
-     */
-    void updateSellingBidStatus(UUID sellingId, SellingStatus newStatus, Long userId, String email);
-
-    /**
      * 판매 입찰 상태 변경 (시스템용)
      */
     void updateSellingBidStatusBySystem(UUID sellingId, SellingStatus newStatus, String email);

--- a/src/main/java/com/example/unbox_be/trade/presentation/controller/SellingBidInternalController.java
+++ b/src/main/java/com/example/unbox_be/trade/presentation/controller/SellingBidInternalController.java
@@ -1,0 +1,20 @@
+package com.example.unbox_be.trade.presentation.controller;
+
+import com.example.unbox_be.trade.application.service.SellingBidService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/bids/selling")
+@RequiredArgsConstructor
+public class SellingBidInternalController {
+
+    private final SellingBidService sellingBidService;
+
+//    // ✅ 최저가 일괄 조회
+//    @GetMapping("/lowest-prices")
+//    public CustomApiResponse<Map<UUID, Integer>> getLowestPrices(@RequestParam("productOptionIds") List<UUID> productOptionIds) {
+//        return sellingBidService.getLowestPricesByProductOptionIds(productOptionIds);
+//    }
+}


### PR DESCRIPTION
## 📋 이슈 번호
- Issue: Closes #177

## 🛠️ 작업 내용
- [ ] 상품 서비스에서 최저가(lowestPrice) 관련 로직 및 응답 필드 제거
- [ ] 타 서비스(Order/Selling) Enum 및 Repository 의존성 제거

## 📸 테스트 결과 (스크린샷/로그)

## 💬 리뷰 포인트
- Product 서비스가 다른 도메인에 의존하지 않도록 경계 분리가 잘 되었는지 확인

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일/빌드 되나요?
- [ ] 로컬 환경에서 테스트를 완료했나요?
- [ ] 불필요한 주석이나 디버깅 코드는 제거했나요?
- [ ] 브랜치 전략(Git Flow Lite)을 준수했나요? (develop -> feat/...)