### PR TITLE
fix: widen security permissions for concurrency test endpoint

### DIFF
--- a/unbox_trade/src/main/java/com/example/unbox_trade/common/config/SecurityConfig.java
+++ b/unbox_trade/src/main/java/com/example/unbox_trade/common/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
             // Internal API (Feign)
             .requestMatchers("/internal/**").permitAll()
             // Test API (Concurrency Testing)
-            .requestMatchers("/api/trade/purchase/test", "/trade/api/trade/purchase/test").permitAll()
+            .requestMatchers("/api/trade/purchase/**", "/trade/api/trade/purchase/**").permitAll()
             .requestMatchers("/error").permitAll()
             // Admin API
             .requestMatchers("/api/admin/**").hasAnyAuthority("ROLE_MASTER", "ROLE_MANAGER")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩토링**
  * 구매 관련 API 엔드포인트의 공개 접근 범위가 확대되었습니다. 기존의 특정 테스트 엔드포인트 제한에서 벗어나, /api/trade/purchase/** 및 /trade/api/trade/purchase/** 경로 아래의 모든 엔드포인트에 대한 공개 접근이 이제 허용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->