### PR TITLE
docs: Add detailed documentation for Trade Service and User Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,6 @@ logs/
 *.log
 
 .spec
-docs/
 
 ### VS Code ###
 .vscode/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@
 - 적용된 디자인 패턴과 트레이드오프
 - 핵심 시퀀스 다이어그램, ERD(핵심 도메인)
 
+## 1.5 서비스별 심화 문서
+
+서비스별 백엔드 Deep Dive 문서는 아래 경로에서 확인할 수 있습니다.
+
+- 인덱스: `docs/services/README.md`
+- User: `docs/services/user-service.md`
+- Product: `docs/services/product-service.md`
+- Trade: `docs/services/trade-service.md`
+- Order: `docs/services/order-service.md`
+- Payment: `docs/services/payment-service.md`
+
 ---
 
 ## 2. 빠른 시작 (Local)
@@ -881,3 +892,4 @@ unbox_workspace/
 - Payment Outbox, Trade 동시성 전략, Order CircuitBreaker로 운영 안정성 강화
 
 이 README만 읽어도, 로컬 실행부터 서비스 간 흐름/운영 포인트까지 빠르게 온보딩할 수 있도록 구성했습니다.
+

--- a/docs/services/README.md
+++ b/docs/services/README.md
@@ -1,0 +1,17 @@
+# Service Deep Dive
+
+이 디렉토리는 `unbox_workspace`의 서비스별 백엔드 심화 문서를 제공합니다.
+
+- [User Service](./user-service.md)
+- [Product Service](./product-service.md)
+- [Trade Service](./trade-service.md)
+- [Order Service](./order-service.md)
+- [Payment Service](./payment-service.md)
+
+권장 읽기 순서
+
+1. User Service
+2. Product Service
+3. Trade Service
+4. Order Service
+5. Payment Service

--- a/docs/services/order-service.md
+++ b/docs/services/order-service.md
@@ -1,0 +1,532 @@
+# Order Service Deep Dive
+
+## 1. 왜 Order Service를 분리했는가
+
+### 이유
+
+Order Service는 "입찰 체결 이후의 거래 수명주기"를 소유하는 프로세스 중심 도메인입니다.
+
+- Trade가 입찰 상태를 소유한다면, Order는 주문 상태 머신을 소유합니다.
+- 결제, 배송, 검수, 환불, 정산으로 이어지는 후속 흐름은 단일 CRUD보다 오케스트레이션 성격이 강합니다.
+- 상태 전이 규칙이 많고, 운영 정책 변경(환불/배송기한/검수 프로세스)이 잦아 독립 배포가 유리합니다.
+- Redis 타임아웃과 Kafka 이벤트를 함께 다루는 비동기 조정 로직을 주문 경계에 집중시킬 수 있습니다.
+
+### 역할
+
+- 주문 생성/조회/취소/환불 요청
+- 결제 완료 이벤트 반영 (`PAYMENT_PENDING -> PENDING_SHIPMENT`)
+- 배송 기한 만료 자동 처리
+- 검수 시작/합격/불합격 흐름 연동
+- 정산 생성/확정/취소 트리거
+- 주문 관련 이벤트(`order-events`) 발행
+
+### 비책임
+
+- 결제 승인/PG 통신 자체
+- 입찰 선점 알고리즘 자체
+- 사용자 인증 원천 데이터 소유
+
+---
+
+## 2. 서비스 접근 URL
+
+### URL
+
+- Order Swagger (dev): `https://dev.un-box.click/order/swagger-ui/index.html`
+- Order Swagger (local): `http://localhost:8080/order/swagger-ui/index.html`
+- Order API Base (dev): `https://dev.un-box.click/order`
+- Grafana (dev): `https://grafana.dev.un-box.click/`
+
+### 참고
+
+- `application.yml` 기준 컨텍스트 경로는 `/order`
+- Security 설정에서 ALB prefix Swagger 경로(`/order/**`)를 permit 처리
+
+---
+
+## 3. 아키텍처 개요
+
+### 구조
+
+- Presentation: 사용자/관리자/내부 컨트롤러
+- Application: 주문/검수/정산 유즈케이스 서비스 + 이벤트 리스너/프로듀서
+- Domain: `Order`, `Inspection`, `Settlement`, `ConsumerReceivedLog`
+- Infrastructure: Redis TTL Listener, Kafka, Feign + Circuit Breaker
+
+### 패키지
+
+- `order/application/service`
+  - `OrderServiceImpl`, `AdminOrderServiceImpl`, `InspectionServiceImpl`
+  - `ConsumerReceivedLogService`
+- `order/application/event`
+  - `OrderEventListener` (payment-events 소비)
+  - `RedisKeyExpiredListener` (Redis 만료 이벤트 소비)
+  - `OrderEventProducer` (order-events 발행)
+- `settlement/application`
+  - `SettlementService`
+  - `SettlementEventListener`
+- `common/client`
+  - `TradeClient`, `UserClient`, `PaymentClient`
+  - `TradeClientFallbackFactory` (Resilience 보강)
+
+### 런타임
+
+```mermaid
+flowchart LR
+    Client -->|HTTP| OrderSvc[Order Service]
+    OrderSvc -->|JPA| OrderDB[(Order DB)]
+    OrderSvc -->|Redis TTL| Redis[(Redis)]
+    OrderSvc -->|Feign| TradeSvc[Trade Service]
+    OrderSvc -->|Feign| UserSvc[User Service]
+    OrderSvc -->|Feign| PaymentSvc[Payment Service]
+    PaymentSvc -->|payment-events| Kafka[(Kafka)]
+    OrderSvc -->|order-events| Kafka
+    Kafka -->|order-events consume| PaymentSvc
+    Kafka -->|order-events consume| TradeSvc
+    Kafka -->|order-events consume| SettlementListener[SettlementEventListener]
+```
+
+---
+
+## 4. Spring Boot 사용 방식
+
+### 기술 매핑
+
+| 영역            | 사용 기술                                  | 적용 위치                                                             | 사용 목적                 |
+| :-------------- | :----------------------------------------- | :-------------------------------------------------------------------- | :------------------------ |
+| Web             | Spring MVC                                 | `OrderController`, `Admin*Controller`, `OrderInternalController`      | Public/Admin/Internal API |
+| Security        | Spring Security + JWT Filter               | `SecurityConfig`                                                      | 인증/인가                 |
+| Method Security | `@EnableMethodSecurity`, `@PreAuthorize`   | 서비스/관리자 컨트롤러                                                | 관리자 권한 제한          |
+| Persistence     | Spring Data JPA + Querydsl                 | `OrderRepository`, `AdminOrderRepositoryCustomImpl`                   | 주문/관리자 검색          |
+| Messaging       | Spring Kafka                               | `OrderEventListener`, `SettlementEventListener`, `OrderEventProducer` | 이벤트 기반 상태 반영     |
+| Cache/Event     | RedisTemplate + KeyExpirationEventListener | `OrderServiceImpl`, `RedisKeyExpiredListener`                         | 결제/배송/매칭 타임아웃   |
+| Service Call    | OpenFeign + Resilience4j CB                | `TradeClient`, `TradeClientFallbackFactory`                           | 외부 서비스 호출 안정성   |
+| Mapping         | MapStruct                                  | `OrderMapper`, `OrderClientMapper`, `Settlement*Mapper`               | DTO 매핑 일관성           |
+| Observability   | Actuator + Micrometer + OTel               | `application.yml`                                                     | 메트릭/트레이싱           |
+
+### 설정 특징
+
+- `server.servlet.context-path: /order`
+- Kafka consumer: `group-id=order-group`, `enable-auto-commit=false`, `StringDeserializer`
+- Feign Circuit Breaker 활성화: `spring.cloud.openfeign.circuitbreaker.enabled=true`
+- Resilience4j: `unbox-trade` 인스턴스 개별 튜닝(`waitDurationInOpenState`, `slowCallDurationThreshold`)
+- Redis Keyspace Listener 사용 (`RedisMessageListenerContainer`)
+
+---
+
+## 5. API 계약
+
+### Public API
+
+#### 사용자 주문
+
+- `POST /order/api/orders`
+- `GET /order/api/orders`
+- `GET /order/api/orders/{orderId}`
+- `PATCH /order/api/orders/{orderId}/cancel`
+- `PATCH /order/api/orders/{orderId}/tracking`
+- `PATCH /order/api/orders/{orderId}/confirm`
+- `PATCH /order/api/orders/{orderId}/refund`
+
+#### 관리자 주문
+
+- `GET /order/api/admin/orders`
+- `GET /order/api/admin/orders/{orderId}`
+- `PATCH /order/api/admin/orders/{orderId}/status`
+
+#### 관리자 검수
+
+- `POST /order/api/admin/inspections/start`
+- `POST /order/api/admin/inspections/{inspectionId}/pass`
+- `POST /order/api/admin/inspections/{inspectionId}/fail`
+- `GET /order/api/admin/inspections/{orderId}`
+
+### Internal API
+
+#### 주문 내부
+
+- `GET /order/internal/orders/{id}/for-review`
+- `GET /order/internal/orders/{id}/for-payment`
+- `POST /order/internal/orders/{id}/pending-shipment`
+
+#### 정산 내부
+
+- `GET /order/internal/settlement/{id}/for-payment`
+- `POST /order/internal/settlement/create?paymentId=...`
+
+### 보안 정책 요약
+
+- Swagger/Actuator: permitAll
+- `/internal/**`: permitAll
+- `/api/admin/**`: `ROLE_MASTER`, `ROLE_MANAGER` (Security filter chain)
+- 그 외 API: 인증 필요
+
+---
+
+## 6. 도메인 모델과 상태 전이
+
+### 이유
+
+Order는 외부 도메인(User/Product/Trade)와 강결합 FK를 줄이고, 주문 시점 스냅샷을 저장해 거래 이력 해석 안정성을 높입니다.
+
+### 엔티티
+
+- `p_orders`
+  - 강한 참조: `selling_bid_id`, `buying_bid_id`, `buyer_id`, `seller_id`
+  - 약한 참조: `product_id`, `product_option_id`
+  - 스냅샷: `buyer_name`, `product_name`, `product_option_name`, `brand_name`, `model_number`
+  - 배송정보: 수령인/주소/운송장, `payment_id`
+- `p_inspections`
+  - `order_id` unique, `inspector_id`, `inspect_status`, `reason`
+- `p_settlements`
+  - `order_id`, `payment_id`, `seller_id`, `fees_amount`, `pay_out_amount`, `status`
+- `consumer_received_log`
+  - `(event_id, consumer_group)` unique 제약으로 중복 기록 방지
+
+### OrderStatus
+
+- `PAYMENT_PENDING`
+- `PENDING_SHIPMENT`
+- `SHIPPED_TO_CENTER`
+- `ARRIVED_AT_CENTER`
+- `IN_INSPECTION`
+- `INSPECTION_PASSED`
+- `INSPECTION_FAILED`
+- `SHIPPED_TO_BUYER`
+- `DELIVERED`
+- `COMPLETED`
+- `CANCELLED`
+
+### 주요 전이 경로
+
+- 주문 생성: `PAYMENT_PENDING`
+- 결제 완료 이벤트: `PAYMENT_PENDING -> PENDING_SHIPMENT`
+- 판매자 운송장 등록: `PENDING_SHIPMENT -> SHIPPED_TO_CENTER`
+- 관리자 검수 플로우:
+  - `SHIPPED_TO_CENTER -> ARRIVED_AT_CENTER -> IN_INSPECTION`
+  - `IN_INSPECTION -> INSPECTION_PASSED|INSPECTION_FAILED`
+  - `INSPECTION_PASSED -> SHIPPED_TO_BUYER -> DELIVERED`
+- 구매 확정: `DELIVERED -> COMPLETED`
+- 취소/환불/배송기한 만료: `-> CANCELLED`
+
+### ERD
+
+```mermaid
+erDiagram
+    P_ORDERS {
+      UUID order_id PK
+      UUID selling_bid_id
+      UUID buying_bid_id
+      BIGINT buyer_id
+      BIGINT seller_id
+      UUID product_id
+      UUID product_option_id
+      UUID payment_id
+      DECIMAL price
+      VARCHAR status
+      VARCHAR receiver_name
+      VARCHAR tracking_number
+      DATETIME cancelled_at
+      DATETIME completed_at
+    }
+
+    P_INSPECTIONS {
+      UUID inspection_id PK
+      UUID order_id UK
+      BIGINT inspector_id
+      VARCHAR inspect_status
+      TEXT reason
+      DATETIME completed_at
+    }
+
+    P_SETTLEMENTS {
+      UUID settlement_id PK
+      UUID order_id
+      UUID payment_id
+      BIGINT seller_id
+      DECIMAL total_amount
+      DECIMAL fees_amount
+      DECIMAL pay_out_amount
+      VARCHAR status
+    }
+
+    CONSUMER_RECEIVED_LOG {
+      UUID consumer_received_log_id PK
+      UUID event_id
+      VARCHAR event_type
+      UUID payment_id
+      VARCHAR payment_key
+      VARCHAR topic
+      VARCHAR consumer_group
+      DATETIME received_at
+    }
+
+    P_ORDERS ||--o| P_INSPECTIONS : has
+    P_ORDERS ||--o| P_SETTLEMENTS : has
+```
+
+---
+
+## 7. 통신/일관성 설계
+
+### 이유
+
+Order는 동기 선점 검증과 비동기 후속 반영을 조합해 응답시간과 정합성을 균형 맞추는 구조입니다.
+
+### 동기 통신 (Feign)
+
+- `TradeClient`
+  - 입찰 조회/선점/복구/매칭리셋
+- `UserClient`
+  - 주문자 정보 조회, 판매자 기본 계좌 보유 여부 확인
+- `PaymentClient`
+  - 정산 생성 시 결제 정보 조회
+
+### 장애 대응
+
+- Trade 호출은 `TradeClientFallbackFactory`로 예외 타입 분기
+- `FeignClientException`(비즈니스 예외)은 원인 보존
+- Circuit Open/네트워크 장애는 `SERVICE_UNAVAILABLE`로 fail-fast
+
+### 비동기 통신 (Kafka)
+
+#### Producer (`order-events`)
+
+- `OrderCancelled`
+- `OrderExpired`
+- `OrderConfirmed`
+- `OrderRefundRequested`
+- `OrderShipmentExpired`
+
+#### Consumer
+
+- `payment-events` (`OrderEventListener`)
+  - `PaymentCompleted` 수신 후 `pendingShipmentOrder` 호출
+- `payment-events`/`order-events` (`SettlementEventListener`)
+  - 결제완료 시 정산 생성
+  - 환불/배송기한만료 시 정산 취소
+
+### Redis 타임아웃 키
+
+- `order:expiration:{orderId}:{type}:{bidId}`
+  - 결제 제한시간 만료 트리거 (`type=SELLING|BUYING`)
+- `order:shipment-deadline:{orderId}`
+  - 판매자 미발송 타임아웃
+- `buying-bid:match-timeout:{buyingBidId}`
+  - 구매입찰 매칭 타임아웃 키 만료 감지 후 Trade reset 호출
+
+### 정합성 특성
+
+- 주문 생성 시 외부 선점 성공 후 Redis 타이머 설정 실패하면 보상 호출(`liveSellingBid/liveBuyingBid`)
+- 배송 기한 만료는 DB 상태 변경 후 이벤트 발행으로 후속 서비스 환불/정산 취소를 트리거
+
+---
+
+## 8. 핵심 시퀀스
+
+### 판매입찰 기반 주문 생성
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Buyer
+    participant O as OrderService
+    participant UC as UserClient
+    participant TC as TradeClient
+    participant DB as OrderDB
+    participant R as Redis
+
+    U->>O: createOrder(sellingBidId, shipping info)
+    O->>UC: getUserInfoForOrder(buyerId)
+    O->>TC: getSellingBidForOrder(sellingBidId)
+    O->>TC: reserveSellingBid(LIVE->RESERVED)
+    O->>DB: Order 저장(PAYMENT_PENDING)
+    O->>R: SET order:expiration:{orderId}:SELLING:{bidId} TTL
+    O-->>U: orderId
+```
+
+### 구매입찰 기반 주문 생성
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Bidder
+    participant O as OrderService
+    participant TC as TradeClient
+    participant UC as UserClient
+    participant DB as OrderDB
+    participant R as Redis
+
+    U->>O: createOrder(buyingBidId)
+    O->>TC: getBuyingBidForOrder(buyingBidId)
+    O->>O: MATCHED 상태 + 본인(Buyer) 검증
+    O->>TC: reserveBuyingBid(MATCHED->RESERVED)
+    O->>DB: Order 저장(PAYMENT_PENDING)
+    O->>R: DEL buying-bid:match-timeout:{buyingBidId}
+    O->>R: SET order:expiration:{orderId}:BUYING:{bidId} TTL
+    O-->>U: orderId
+```
+
+### 결제 완료 이벤트 반영
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant P as Payment Service
+    participant K as Kafka
+    participant L as OrderEventListener
+    participant O as OrderService
+    participant R as Redis
+
+    P->>K: PaymentCompleted(EventEnvelope)
+    K-->>L: payment-events 전달
+    L->>O: pendingShipmentOrder(orderId, paymentId)
+    O->>O: PAYMENT_PENDING->PENDING_SHIPMENT
+    O->>R: SET order:shipment-deadline:{orderId}
+```
+
+### 배송 미발송 타임아웃
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant R as Redis
+    participant L as RedisKeyExpiredListener
+    participant O as OrderService
+    participant K as Kafka
+    participant T as Trade
+    participant P as Payment
+    participant S as Settlement
+
+    R-->>L: order:shipment-deadline:{orderId} expired
+    L->>O: processShipmentOverdue(orderId)
+    O->>O: PENDING_SHIPMENT->CANCELLED
+    O->>K: OrderShipmentExpired 발행
+    K-->>T: 입찰 상태 복구/취소 처리
+    K-->>P: 결제 환불 처리
+    K-->>S: 정산 취소 처리
+```
+
+---
+
+## 9. 디자인 패턴과 적용 이유
+
+### 이유
+
+Order는 다수 서비스와 상호작용하는 프로세스 계층이라 설계 의도를 패턴으로 고정해야 변경 시 안정성이 유지됩니다.
+
+### 패턴
+
+| 패턴                     | 코드 위치                                | 적용 이유                    |
+| :----------------------- | :--------------------------------------- | :--------------------------- |
+| Saga-like Choreography   | `order-events`/`payment-events` 연쇄     | 2PC 없이 서비스 간 상태 전파 |
+| Circuit Breaker Pattern  | `application.yml` + Feign CB             | 외부 장애 전파 차단          |
+| Fallback Factory Pattern | `TradeClientFallbackFactory`             | 예외 원인별 fallback 분기    |
+| Observer Pattern         | Kafka Listener/Producer                  | 비동기 후속처리              |
+| State Machine Pattern    | `Order#validateAdminStatusTransition` 등 | 불법 상태 전이 차단          |
+| Compensation Pattern     | `createOrder` 보상 호출                  | 부분 실패 시 선점 복구       |
+| Idempotency Pattern      | `ConsumerReceivedLog` unique 제약        | 이벤트 중복 기록 방지        |
+| Repository Pattern       | `*Repository`                            | 도메인/영속성 분리           |
+| Snapshot Pattern         | `Order` 스냅샷 필드                      | 원격 변경과 무관한 이력 보존 |
+| Builder Pattern          | 엔티티/DTO 생성                          | 가독성 및 생성 안정성        |
+
+---
+
+## 10. CS 관점
+
+### 핵심
+
+- Sync + Async Hybrid
+  - 생성 시에는 동기 선점으로 강한 검증,
+  - 후속 전이는 Kafka/Redis 이벤트로 비동기 처리합니다.
+- Failure Isolation
+  - CB + fallback으로 외부 장애를 주문 서비스 내부에서 제한합니다.
+- Timeout-driven Workflow
+  - Redis key-expired를 트리거로 사용해 스케줄러 폴링 부담을 줄입니다.
+- Eventual Consistency
+  - Trade/Payment/Settlement 반영은 일시적 불일치를 허용하는 모델입니다.
+- Process-centered Domain
+  - Order는 데이터 저장소이면서 상태 머신 엔진 역할을 동시에 수행합니다.
+
+---
+
+## 11. 보완해야 할 사항 (우선순위)
+
+### P0
+
+1. Redis 만료 키 파싱 로직 오류
+
+- `RedisKeyExpiredListener#handleOrderExpired`는 `parts.length != 4` 검사 후 `parts[4]`를 접근합니다.
+- 현재 생성 키 포맷은 `order:expiration:{orderId}:{type}:{bidId}`라 최소 5조각입니다.
+
+2. 관리자 권한 정책 충돌
+
+- `SecurityConfig`는 `/api/admin/**`를 `MASTER/MANAGER`만 허용합니다.
+- `AdminInspectionController`는 `INSPECTOR` 권한 허용을 선언하지만 filter에서 선차단되어 Inspector 접근이 막힙니다.
+
+3. 결제 완료 후 결제만료 키 정리 부재
+
+- 주문 생성 시 `order:expiration:*`를 생성하지만 결제 완료(`pendingShipmentOrder`)에서 삭제하지 않습니다.
+- 만료 이벤트가 불필요하게 후속 시스템으로 퍼질 수 있습니다.
+
+4. 결제 타임아웃 시 Order 상태 갱신 경로 불명확
+
+- 만료 시 `OrderExpiredEvent`는 발행되지만 Order 서비스 내부에서 `PAYMENT_PENDING -> CANCELLED`를 명시적으로 처리하는 소비 경로가 보이지 않습니다.
+
+### P1
+
+1. 검수 권한 검증 불일치
+
+- `InspectionServiceImpl#passInspection`은 검사자 본인 검증이 있지만 `failInspection`에는 동일 검증이 없습니다.
+
+2. 사용자 취소 가능 상태 정책 재점검
+
+- `Order#cancel()`은 `ARRIVED_AT_CENTER`, `IN_INSPECTION` 같은 상태를 직접 금지하지 않습니다.
+- 현재 정책 의도(결제 후 환불 전용)와 실제 도메인 가드가 완전히 일치하는지 확인이 필요합니다.
+
+3. Producer Outbox 부재
+
+- 주문 이벤트는 DB 트랜잭션과 별도로 직접 Kafka 발행합니다.
+- 커밋/발행 사이 장애 구간에 대한 내구성 보강 여지가 있습니다.
+
+4. 이벤트 수신 로그 범위 제한
+
+- `ConsumerReceivedLogService`는 `paymentKey`가 `test_success_*`인 경우에만 기록합니다.
+- 운영 트래픽 전체 멱등/감사 추적에는 부족할 수 있습니다.
+
+### P2
+
+1. 정산 상태 머신 고도화
+
+- `SettlementStatus` enum은 다단계지만 실제 로직은 `PENDING/PAID_OUT/CANCELLED` 중심으로 사용됩니다.
+
+2. 타임아웃/이벤트 관측성 강화
+
+- 키 만료 처리 성공률, 이벤트 지연, 보상 호출 실패율 등 운영 지표를 명시적으로 메트릭화할 필요가 있습니다.
+
+3. 검수 불합격 후 자동 후속처리 명확화
+
+- `INSPECTION_FAILED` 이후 환불/정산취소 자동 연계 정책이 코드상 일관되게 보이지 않아 운영 규칙 문서화가 필요합니다.
+
+---
+
+## 12. 운영 체크리스트
+
+### 체크 항목
+
+- Swagger: `https://dev.un-box.click/order/swagger-ui/index.html`
+- Grafana: `https://grafana.dev.un-box.click/`
+- Kafka:
+  - `payment-events`(order-group) consumer lag
+  - `order-events` produce 실패율
+  - `settlement-group` consumer lag
+- Redis:
+  - `order:expiration:*` 생성/만료량
+  - `order:shipment-deadline:*` 만료 후 처리 성공률
+  - `buying-bid:match-timeout:*` 만료 reset 성공률
+- Circuit Breaker:
+  - `resilience4j_circuitbreaker_state{name="unbox-trade"}`
+  - fallback 발생 빈도
+- 주문 품질:
+  - 상태 전이 실패(`INVALID_ORDER_STATUS*`) 비율
+  - 보상 호출(`ORDER_ROLLBACK`) 실패 로그 추적

--- a/docs/services/payment-service.md
+++ b/docs/services/payment-service.md
@@ -1,0 +1,490 @@
+# Payment Service Deep Dive
+
+## 1. 왜 Payment Service를 분리했는가
+
+### 이유
+
+Payment Service는 "외부 PG 연동 + 결제 상태 머신 + 결제 이벤트 전파"를 독립 경계로 관리하기 위해 분리되었습니다.
+
+- PG(Toss) 호출은 네트워크 지연/장애 전파 가능성이 높아 주문/입찰 도메인과 격리할 필요가 있습니다.
+- 결제는 금액 검증, 중복 승인 방지, 환불, 감사 추적까지 요구되어 단순 CRUD보다 트랜잭션 정책이 중요합니다.
+- 결제 성공/실패를 Trade/Order/Settlement에 비동기로 전달해야 하므로 메시징 신뢰성 패턴(Outbox, 재시도, 복구)을 독립 진화시키기 좋습니다.
+- 결제 도메인 변경 주기(정책/PG API/보안)가 주문/입찰과 달라 독립 배포 이점이 큽니다.
+
+### 역할
+
+- 결제 준비(`READY`) 생성
+- 결제 승인(`READY -> IN_PROGRESS -> DONE|FAILED`)
+- 주문 이벤트 기반 환불(`DONE -> REFUND_IN_PROGRESS -> CANCELED`)
+- 결제 이벤트(`PaymentCompleted`, `PaymentFailed`) 발행
+- 정산/주문 서비스용 내부 조회 API 제공
+
+### 비책임
+
+- 주문 생성/검수/배송 상태 머신 소유
+- 입찰 생성/매칭/선점 소유
+- 사용자 원천 인증 데이터 소유
+
+---
+
+## 2. 서비스 접근 URL
+
+### URL
+
+- Payment Swagger (dev): `https://dev.un-box.click/payment/swagger-ui/index.html`
+- Payment Swagger (local): `http://localhost:8080/payment/swagger-ui/index.html`
+- Payment API Base (dev): `https://dev.un-box.click/payment`
+- Grafana (dev): `https://grafana.dev.un-box.click/`
+
+### 참고
+
+- `application.yml` 기준 컨텍스트 경로는 `/payment`
+- Security 설정에서 ALB prefix Swagger 경로(`/payment/**`) permit 처리
+- OpenAPI 서버 정의에는 구 ALB URL도 함께 남아 있음
+
+---
+
+## 3. 아키텍처 개요
+
+### 구조
+
+- Presentation: `PaymentController`, `PaymentInternalController`
+- Application: `PaymentServiceImpl`, `PaymentTransactionService`, `TossApiService`
+- Event: `PaymentOutboxWriter`, `PaymentOutboxMessageRelay`, `OrderRefundEventListener`
+- Domain: `Payment`, `PgTransaction`, `PaymentOutboxEvent`
+- Infrastructure: Kafka, Feign(Order), Scheduler, JPA
+
+### 패키지
+
+- `payment/application/service`
+  - `PaymentServiceImpl`, `PaymentTransactionService`, `PaymentOutboxService`, `TossApiService`
+- `payment/application/event`
+  - `listener/OrderRefundEventListener`
+  - `producer/PaymentEventProducer`, `PaymentDirectAsyncEventProducer`
+  - `relay/PaymentOutboxMessageRelay`
+- `payment/domain`
+  - `entity/Payment`, `PgTransaction`, `PaymentOutboxEvent`
+  - `repository/*Repository`
+- `common/client`
+  - `OrderClient` (실사용)
+  - `SettlementClient`, `TradeClient` (현재 미사용)
+
+### 런타임
+
+```mermaid
+flowchart LR
+    Client -->|HTTP| PaymentSvc[Payment Service]
+    PaymentSvc -->|JPA| PaymentDB[(Payment DB)]
+    PaymentSvc -->|Feign| OrderSvc[Order Service]
+    PaymentSvc -->|Toss API| Toss[(Toss Payments)]
+    PaymentSvc -->|payment-events| Kafka[(Kafka)]
+    OrderSvc -->|order-events| Kafka
+    Kafka -->|order-events consume| PaymentSvc
+```
+
+---
+
+## 4. Spring Boot 사용 방식
+
+### 기술 매핑
+
+| 영역            | 사용 기술                         | 적용 위치                                        | 사용 목적                          |
+| :-------------- | :-------------------------------- | :----------------------------------------------- | :--------------------------------- |
+| Web             | Spring MVC                        | `PaymentController`, `PaymentInternalController` | Public/Internal API                |
+| Security        | Spring Security + JWT Filter      | `SecurityConfig`                                 | 무상태 인증/인가                   |
+| Method Security | `@EnableMethodSecurity`           | `SecurityConfig`                                 | 메서드 권한 확장 기반              |
+| Persistence     | Spring Data JPA                   | `PaymentRepository`, `PgTransactionRepository`   | 결제/PG이력/Outbox 영속성          |
+| Messaging       | Spring Kafka                      | Producer/Listener/Relay                          | 결제 이벤트 발행, 주문 이벤트 소비 |
+| Scheduling      | `@EnableScheduling`, `@Scheduled` | `PaymentOutboxMessageRelay`                      | Outbox 릴레이/복구                 |
+| Service Call    | OpenFeign                         | `OrderClient`                                    | 결제 대상 주문 검증                |
+| Mapping         | MapStruct                         | `PaymentMapper`, `PgTransactionMapper`           | DTO/Entity 매핑 일관화             |
+| Docs            | springdoc-openapi                 | `SwaggerConfig`                                  | Swagger/OpenAPI                    |
+| Observability   | Actuator + Micrometer + OTel      | `application.yml`                                | health/metric/trace                |
+
+### 설정 특징
+
+- `server.servlet.context-path: /payment`
+- Kafka: `group-id=payment-group`, `enable-auto-commit=false`, producer `acks=all`
+- Outbox 릴레이: `@Scheduled(fixedDelay = 1000)`
+- Stuck 복구: `@Scheduled(fixedDelay = 60000, initialDelay = 60000)`
+- DB 커넥션 풀: `maximum-pool-size=5`
+- Dev/Prod 프로파일은 MSK IAM(`SASL_SSL`, `AWS_MSK_IAM`) 설정 사용
+
+---
+
+## 5. API 계약
+
+### Public API
+
+#### 사용자 결제
+
+- `GET /payment/api/payment/history`
+- `POST /payment/api/payment/ready`
+- `POST /payment/api/payment/confirm`
+
+### Internal API
+
+#### 내부 결제 조회
+
+- `GET /payment/internal/payments/{paymentId}/for-settlement`
+- `GET /payment/internal/payments/orders/{orderId}/status`
+
+### 이벤트 소비
+
+- Topic: `order-events`
+- Event:
+  - `OrderRefundRequested`
+  - `OrderShipmentExpired`
+
+### 보안 정책 요약
+
+- Swagger/Actuator: permitAll
+- `/internal/**`: permitAll
+- `/api/admin/**`: `ROLE_MASTER`, `ROLE_MANAGER`
+- 그 외 API: 인증 필요
+
+---
+
+## 6. 도메인 모델과 상태 전이
+
+### 이유
+
+Payment는 결제 원장(`Payment`), PG 외부 트랜잭션 로그(`PgTransaction`), 이벤트 전달 보장(`PaymentOutboxEvent`)을 분리해 책임을 명확히 유지합니다.
+
+### 엔티티
+
+- `p_payment`
+  - 주문/입찰/구매자/판매자 참조
+  - 결제 수단/금액/상태/준비시각/승인시각
+  - `@Version` 기반 낙관적 락
+- `p_pg_transaction`
+  - 결제 승인/실패/취소 등 PG 거래 이력 저장
+  - `payment_key`, `transaction_key`, `status`, `transaction_at`
+- `payment_outbox`
+  - 발행 대기 이벤트 저장
+  - `status(PENDING/PROCESSING/PUBLISHED/FAILED)`, `retry_count`, `published_at`
+
+### 상태
+
+- `PaymentStatus`
+  - `READY`, `IN_PROGRESS`, `DONE`, `REFUND_IN_PROGRESS`, `CANCELED`, `FAILED`
+- `PaymentOutboxEventStatus`
+  - `PENDING`, `PROCESSING`, `PUBLISHED`, `FAILED`
+- `PgTransactionStatus`
+  - `READY`, `IN_PROGRESS`, `DONE`, `CANCELED`, `FAILED`, `EXPIRED` 등
+
+### 주요 전이
+
+- 준비: `createPayment` -> `READY`
+- 승인 시도: `READY -> IN_PROGRESS`
+- 승인 성공: `IN_PROGRESS -> DONE`
+- 승인 실패: `IN_PROGRESS -> FAILED`
+- 환불: `DONE -> REFUND_IN_PROGRESS -> CANCELED`
+
+### ERD
+
+```mermaid
+erDiagram
+    P_PAYMENT {
+      UUID payment_id PK
+      UUID order_id
+      UUID selling_bid_id
+      UUID buying_bid_id
+      BIGINT buyer_id
+      BIGINT seller_id
+      VARCHAR payment_key
+      VARCHAR method
+      DECIMAL amount
+      VARCHAR status
+      DATETIME ready_at
+      DATETIME approved_at
+      BIGINT version
+      DATETIME created_at
+      DATETIME updated_at
+      DATETIME deleted_at
+    }
+
+    P_PG_TRANSACTION {
+      UUID pg_transaction_id PK
+      UUID payment_id FK
+      VARCHAR transaction_key
+      VARCHAR payment_key
+      UUID order_id
+      VARCHAR method
+      VARCHAR status
+      DECIMAL amount
+      DATETIME transaction_at
+      DATETIME created_at
+      DATETIME deleted_at
+    }
+
+    PAYMENT_OUTBOX {
+      UUID outbox_event_id PK
+      VARCHAR aggregate_type
+      UUID aggregate_id
+      VARCHAR event_type
+      TEXT payload
+      VARCHAR status
+      INT retry_count
+      DATETIME published_at
+      TEXT error_message
+      DATETIME created_at
+      DATETIME updated_at
+      DATETIME deleted_at
+    }
+
+    P_PAYMENT ||--o{ P_PG_TRANSACTION : has
+    P_PAYMENT ||--o{ PAYMENT_OUTBOX : emits
+```
+
+---
+
+## 7. 통신/일관성 설계
+
+### 이유
+
+Payment는 결제 승인 같은 외부 I/O 구간과 상태 변경 구간을 분리해 응답 지연과 데이터 정합성을 동시에 관리하려는 구조입니다.
+
+### 동기 통신 (Feign)
+
+- `OrderClient`
+  - 주문 결제 가능 상태/금액/구매자 검증 (`/internal/orders/{id}/for-payment`)
+- `SettlementClient`, `TradeClient`
+  - 클라이언트 인터페이스는 존재하지만 현재 Payment 서비스 런타임 경로에서는 사용되지 않음
+
+### 비동기 통신 (Kafka)
+
+#### Producer (`payment-events`)
+
+- `PaymentCompleted`
+- `PaymentFailed`
+- Payload는 `EventEnvelope` 표준(`eventId`, `eventType`, `occurredAt`, `aggregateId`, `data`)
+
+#### Consumer (`order-events`)
+
+- `OrderRefundRequested`
+- `OrderShipmentExpired`
+- 수신 후 `paymentService.processRefund(paymentId, reason)` 실행
+
+### Redis 사용 현황
+
+- `application.yml`에 Redis 연결 설정은 존재
+- 현재 Payment 서비스 도메인 코드에서는 RedisTemplate/캐시를 사용하지 않음
+
+### Outbox 릴레이 요약
+
+- PENDING 이벤트를 배치로 Claim
+- 상태를 PROCESSING으로 전환
+- Kafka 발행 성공 시 PUBLISHED, 실패 시 재시도(PENDING) 또는 FAILED
+- 5분 이상 PROCESSING으로 남은 이벤트를 복구 스케줄러가 재대기 상태로 복원
+
+---
+
+## 8. 핵심 시퀀스
+
+### 결제 준비
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant P as Payment Service
+    participant O as Order Service
+    participant DB as Payment DB
+
+    U->>P: POST /api/payment/ready(orderId, method)
+    P->>O: getOrderForPayment(orderId)
+    P->>P: buyer/price/status 검증
+    P->>DB: Payment(status=READY) 저장
+    P-->>U: paymentId, orderId, price
+```
+
+### 결제 승인 성공 (기본 Outbox 경로)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant P as Payment Service
+    participant O as Order Service
+    participant TOSS as Toss API
+    participant DB as Payment DB
+    participant OB as payment_outbox
+    participant R as Outbox Relay
+    participant K as Kafka
+
+    U->>P: POST /api/payment/confirm(paymentId, paymentKey, amount)
+    P->>O: 주문/구매자/상태 검증
+    P->>DB: READY->IN_PROGRESS
+    P->>TOSS: confirm(paymentKey, orderId, amount)
+    TOSS-->>P: DONE
+    P->>DB: Payment DONE + PgTransaction 저장
+    P->>OB: PaymentCompleted(PENDING) 저장
+
+    loop 1초 주기
+        R->>OB: pending claim
+        R->>K: publish payment-events
+        R->>OB: mark PUBLISHED
+    end
+```
+
+### 결제 승인 실패
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant P as Payment Service
+    participant TOSS as Toss API
+    participant DB as Payment DB
+    participant OB as payment_outbox
+    participant K as Kafka
+
+    U->>P: confirm
+    P->>TOSS: confirm
+    TOSS-->>P: FAILED
+    P->>DB: Payment FAILED + PgTransaction 저장
+    P->>OB: PaymentFailed(PENDING) 저장
+    P->>K: (relay 통해) PaymentFailed 발행
+```
+
+### 주문 환불/배송만료 이벤트 소비
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant O as Order Service
+    participant K as Kafka
+    participant L as OrderRefundEventListener
+    participant P as Payment Service
+    participant TOSS as Toss API
+    participant DB as Payment DB
+
+    O->>K: OrderRefundRequested / OrderShipmentExpired
+    K-->>L: order-events 전달
+    L->>P: processRefund(paymentId, reason)
+    P->>DB: DONE->REFUND_IN_PROGRESS
+    P->>TOSS: cancel(paymentKey)
+    P->>DB: REFUND_IN_PROGRESS->CANCELED
+```
+
+---
+
+## 9. 디자인 패턴과 적용 이유
+
+### 패턴
+
+| 패턴                         | 코드 위치                                          | 적용 이유                              |
+| :--------------------------- | :------------------------------------------------- | :------------------------------------- |
+| Transactional Outbox Pattern | `PaymentOutboxWriter`, `PaymentOutboxMessageRelay` | DB 상태 변경과 이벤트 발행 결합도 완화 |
+| Polling Publisher Pattern    | `@Scheduled publishPendingEvents`                  | Broker 독립적으로 안정 발행            |
+| Recovery Pattern             | `recoverStuckProcessingEvents`                     | 워커 비정상 종료 후 자동 복구          |
+| Envelope Pattern             | `EventEnvelope`                                    | 다형 이벤트 소비 표준화                |
+| Proxy Pattern                | `@FeignClient`, `KafkaTemplate`                    | 외부 시스템 연동 추상화                |
+| Repository Pattern           | `*Repository`                                      | 도메인 로직/영속성 관심사 분리         |
+| State Machine Pattern        | `PaymentStatus`, `changeStatus`                    | 불법 상태 전이 방지                    |
+| Builder Pattern              | Entity/Event/DTO Builder                           | 생성 코드 가독성 및 누락 방지          |
+| Idempotency Key Pattern      | `TossApiService`의 `Idempotency-Key` 헤더          | PG 재시도 시 중복 승인 방지            |
+
+---
+
+## 10. CS 관점
+
+### 핵심
+
+- External I/O 분리
+  - PG 호출을 DB 트랜잭션과 분리해 커넥션 점유 시간을 줄이는 구조를 지향합니다.
+- At-least-once 메시징
+  - Outbox + 재시도로 이벤트 유실을 줄이되, 중복 소비 가능성을 고려한 소비자 멱등성이 필요합니다.
+- Partition Ordering
+  - aggregateId(입찰/주문 ID)를 키로 사용해 관련 이벤트 순서를 보존합니다.
+- Failure Isolation
+  - 결제 승인 실패와 이벤트 발행 실패를 분리해 후속 재처리가 가능하도록 설계합니다.
+- Eventual Consistency
+  - Trade/Order/Settlement 반영은 비동기라 짧은 시간의 상태 불일치를 허용합니다.
+
+---
+
+## 11. 보완해야 할 사항 (우선순위)
+
+### P0
+
+1. Outbox 원자성 깨짐
+
+- `processSuccessfulPayment/processFailedPayment` 커밋 후 `paymentOutboxWriter.write(...)`를 별도 호출합니다.
+- 결제 상태 변경과 Outbox 저장이 단일 트랜잭션이 아니라 장애 순간에 이벤트 유실 가능성이 있습니다.
+
+2. `@Transactional` Self-Invocation으로 트랜잭션 경계 의도 불일치
+
+- `PaymentTransactionService#prepareForConfirm -> markAsInProgress`
+- `PaymentOutboxMessageRelay#publishPendingEvents -> claimPendingEvents/processEventInSeparateTransaction`
+- 같은 클래스 내부 호출이라 `REQUIRES_NEW`가 적용되지 않아 동시성/격리 의도가 깨질 수 있습니다.
+
+3. 환불 취소 실패를 삼켜도 로컬 상태를 `CANCELED`로 변경
+
+- `TossApiService#cancel`은 예외를 로그만 남기고 swallow 합니다.
+- PG 취소가 실제 실패해도 `completeRefund`가 실행되어 정산/감사 정합성 문제가 생길 수 있습니다.
+
+### P1
+
+1. 내부 API 공개 범위
+
+- `/internal/**`가 permitAll입니다.
+- 게이트웨이/네트워크 ACL 없으면 공격면이 커집니다.
+
+2. 테스트 전용 Direct Async 경로 운영 노출
+
+- `X-Test-Mode: async` 헤더만으로 Outbox 우회 발행이 가능합니다.
+- 운영 프로파일에서 강제 차단(feature flag 또는 profile guard) 필요합니다.
+
+3. Stuck 복구 기준 시각 개선 필요
+
+- 현재 복구 기준은 `created_at` 중심이라 대기열이 오래된 이벤트 처리 중 오탐 가능성이 있습니다.
+- `processing_started_at` 같은 별도 기준 컬럼 도입이 안전합니다.
+
+4. 사용되지 않는 연동 코드 정리
+
+- `TradeClient`, `SettlementClient`, Redis 설정은 현재 런타임 핵심 경로에서 미사용입니다.
+- 운영 문서/코드 간 괴리를 줄이기 위해 정리 또는 사용 목적 명시가 필요합니다.
+
+5. 외부 API 내결함성 보강
+
+- `TossApiService`는 `new RestTemplate()` 단순 호출로 timeout/retry/circuit-breaker 정책이 약합니다.
+
+### P2
+
+1. Outbox 데이터 관리 전략
+
+- 장기 운영 시 `payment_outbox` 아카이빙/파티셔닝 정책 필요
+
+2. 관측성 지표 고도화
+
+- Outbox 상태별 건수, 재시도율, 복구 건수, PG 취소 실패율을 메트릭화해야 원인 분석이 빨라집니다.
+
+3. 요청 DTO 검증 강화
+
+- `@Valid`는 있으나 `PaymentCreateRequestDto`, `PaymentConfirmRequestDto` 필드 제약이 약합니다.
+- null/음수/빈 문자열 정책을 어노테이션으로 명시하는 편이 계약에 안전합니다.
+
+---
+
+## 12. 운영 체크리스트
+
+### 체크 항목
+
+- Swagger: `https://dev.un-box.click/payment/swagger-ui/index.html`
+- Grafana: `https://grafana.dev.un-box.click/`
+- Kafka:
+  - `payment-events` publish 실패율
+  - `order-events` (`payment-group`) consumer lag
+- Outbox:
+  - `PENDING/PROCESSING/FAILED` 건수 추이
+  - retry_count 상위 이벤트
+  - stuck 복구 건수
+- PG 연동:
+  - Toss confirm/cancel 지연(p95/p99)
+  - confirm 실패 코드 분포
+  - cancel 실패 후 재시도 성공률
+- 결제 품질:
+  - `PAYMENT_IN_PROGRESS`, `AMOUNT_MISMATCH`, `PAYMENT_EXPIRED` 비율
+  - 환불 처리 실패 로그/재처리 건수

--- a/docs/services/product-service.md
+++ b/docs/services/product-service.md
@@ -1,0 +1,465 @@
+# Product Service Deep Dive
+
+## 1. 왜 Product Service를 분리했는가
+
+### 이유
+
+Product Service는 "상품 카탈로그 + 탐색/조회 + 리뷰 + 가격 조회 최적화"를 전담하는 Read-heavy 도메인으로 분리되었습니다.
+
+- 상품/브랜드/옵션/리뷰는 조회 트래픽이 매우 높고 쓰기 트래픽보다 비대칭
+- 거래(Trade) 도메인과 가격 계산/매칭 관심사를 분리해야 모델 복잡도를 낮출 수 있음
+- 카탈로그와 AI 요약 기능의 릴리즈 주기가 주문/결제와 다름
+- 가격은 Trade가 소유하고 Product는 캐시/조회 관점으로 소비하는 구조가 자연스러움
+
+### 역할
+
+- 브랜드/상품/옵션 관리
+- 상품 목록/상세/옵션/리뷰 제공
+- 인기 점수/가격 캐시로 조회 최적화
+- AI 리뷰 요약
+- 상품 삭제 이벤트 발행
+
+### 비책임
+
+- 입찰 상태 변경
+- 주문 상태 전이
+- 결제 승인/정산
+
+---
+
+## 2. 서비스 접근 URL
+
+### URL
+
+- Product Swagger (dev): `https://dev.un-box.click/product/swagger-ui/index.html`
+- Product Swagger (local): `http://localhost:8080/product/swagger-ui/index.html`
+- Product API Base (dev): `https://dev.un-box.click/product`
+- Grafana (dev): `https://grafana.dev.un-box.click/`
+
+### 참고
+
+- `application.yml` 기준 컨텍스트 경로는 `/product`
+- OpenAPI 서버 정의에도 `/product` prefix가 반영되어 있음
+
+---
+
+## 3. 아키텍처 개요
+
+### 구조
+
+- Presentation: Controller + API Interface
+- Application: Product/Review/Admin/Ai 유즈케이스 Service
+- Domain: Brand/Product/ProductOption/Review(+Snapshot)
+- Infrastructure: RedisTemplate, Kafka Producer/Consumer, Feign, WebClient(OpenAI)
+
+### 패키지
+
+- `product`: 브랜드/상품/옵션(관리자 + 사용자 조회)
+- `reviews`: 리뷰 CRUD + 내부 리뷰 조회
+- `ai`: 리뷰 요약
+- `common/client`: Trade/Order Feign
+- `product/application/event`: Kafka producer/listener
+
+### 런타임
+
+```mermaid
+flowchart LR
+    Client -->|HTTP| ProductSvc[Product Service]
+    ProductSvc -->|JPA| ProductDB[(Product DB)]
+    ProductSvc -->|Redis| Redis[(Redis)]
+    ProductSvc -->|Feign| TradeSvc[Trade Service]
+    ProductSvc -->|Feign| OrderSvc[Order Service]
+    TradeSvc -->|trade-events| Kafka[(Kafka)]
+    ProductSvc -->|product-events| Kafka
+    ProductSvc -->|WebClient| OpenAI[(OpenAI API)]
+```
+
+---
+
+## 4. Spring Boot 사용 방식
+
+### 기술 매핑
+
+| 영역            | 사용 기술                                | 적용 위치                                    | 사용 목적                   |
+| :-------------- | :--------------------------------------- | :------------------------------------------- | :-------------------------- |
+| Web             | Spring MVC                               | `*Controller`                                | Public/Internal/Admin API   |
+| Security        | Spring Security + JWT Filter             | `SecurityConfig`                             | 인증/권한, 무상태 요청 처리 |
+| Method Security | `@EnableMethodSecurity`, `@PreAuthorize` | Admin 서비스 계층                            | 관리자 권한 강제            |
+| Persistence     | Spring Data JPA                          | `*Repository`, `*Entity`                     | 카탈로그/리뷰 영속성        |
+| Cache/Data      | RedisTemplate                            | `ProductServiceImpl`, `TradeEventListener`   | 상세/가격/인기 키 관리      |
+| Messaging       | Spring Kafka                             | `TradeEventListener`, `ProductEventProducer` | 가격 반영/삭제 전파         |
+| Service Mesh    | OpenFeign                                | `TradeClient`, `OrderClient`                 | 최저가 조회/리뷰 검증       |
+| AI              | WebClient                                | `AiService`                                  | OpenAI 요약 호출            |
+| Docs            | springdoc-openapi                        | `SwaggerConfig`                              | API 문서/서버 정보          |
+| Observability   | Actuator + Micrometer + OTel             | `application.yml`                            | 지표/트레이싱               |
+
+### 설정 특징
+
+- `server.servlet.context-path: /product`
+- Kafka consumer: `enable-auto-commit: false`, Listener에서 `Acknowledgment` 사용
+- Redis 주요 TTL: `product:info:*` 24h, `product:prices:*` 30m
+- Dev/Prod 프로파일에서 MSK IAM 인증(SASL_SSL + AWS_MSK_IAM) 사용
+
+---
+
+## 5. API 계약
+
+### Public API
+
+#### 카탈로그 조회
+
+- `GET /product/api/products`
+- `GET /product/api/products/{productId}`
+- `GET /product/api/products/{productId}/options`
+- `GET /product/api/products/brands`
+- `GET /product/api/products/{productId}/reviews`
+
+#### 리뷰
+
+- `POST /product/api/reviews`
+- `GET /product/api/reviews/my-reviews`
+- `GET /product/api/reviews/{reviewId}`
+- `PATCH /product/api/reviews/{reviewId}`
+- `DELETE /product/api/reviews/{reviewId}`
+
+#### AI
+
+- `GET /product/api/ai/reviews/summary/{productId}`
+
+#### 관리자
+
+- `GET/POST/PATCH/DELETE /product/api/admin/brands*`
+- `GET/POST/PATCH/DELETE /product/api/admin/products*`
+- `GET/POST/DELETE /product/api/admin/products/{productId}/options*`
+
+### Internal API
+
+- `GET /product/internal/products/options/{id}/for-order`
+- `GET /product/internal/products/options/{id}/for-selling-bid`
+- `GET /product/internal/products/options/{id}/for-buying-bid`
+- `GET /product/internal/reviews/products/{productId}`
+
+### 테스트 API
+
+- `GET /product/api/test/products/v1`
+- `GET /product/api/test/products/v2`
+
+### 보안 정책 요약
+
+- `/api/admin/**`: `ROLE_MASTER`, `ROLE_MANAGER`만 허용
+- `/internal/**`: 현재 permitAll (네트워크/게이트웨이 레벨 보호 필요)
+- `/api/test/products/**`: 현재 permitAll (테스트 목적)
+- 그 외: 인증 필요
+
+---
+
+## 6. 데이터 모델 (Service-local)
+
+### 이유
+
+카탈로그는 정규화 관계를 유지하고, 리뷰는 스냅샷을 내장해 과거 무결성을 보장하는 혼합 모델을 채택했습니다.
+
+### 엔티티
+
+- `p_brands`: 브랜드 마스터
+- `p_products`: 상품 마스터, `reviewCount/totalScore/popularityScore` 포함
+- `p_product_options`: 상품 옵션
+- `p_review`: 리뷰 본문 + 작성자/주문/상품 스냅샷
+
+### 모델 특징
+
+- Product는 Brand에 ManyToOne
+- ProductOption은 Product에 ManyToOne
+- Review는 `ReviewProductSnapshot(@Embeddable)`를 저장해 과거 정보 보존
+- 공통적으로 `BaseEntity + @SQLRestriction("deleted_at IS NULL")` 기반 soft-delete
+
+### ERD
+
+```mermaid
+erDiagram
+    P_BRANDS {
+      UUID brand_id PK
+      VARCHAR name
+      VARCHAR image_url
+    }
+
+    P_PRODUCTS {
+      UUID product_id PK
+      UUID brand_id FK
+      VARCHAR product_name
+      VARCHAR model_number
+      VARCHAR category
+      BIGINT popularity_score
+      INT review_count
+      INT total_score
+    }
+
+    P_PRODUCT_OPTIONS {
+      UUID product_option_id PK
+      UUID product_id FK
+      VARCHAR name
+    }
+
+    P_REVIEW {
+      UUID review_id PK
+      UUID order_id
+      BIGINT buyer_id
+      VARCHAR buyer_nickname
+      UUID product_id
+      UUID product_option_id
+      VARCHAR product_name
+      VARCHAR product_option_name
+      VARCHAR brand_name
+      INT rating
+    }
+
+    P_BRANDS ||--o{ P_PRODUCTS : has
+    P_PRODUCTS ||--o{ P_PRODUCT_OPTIONS : has
+```
+
+---
+
+## 7. 캐시/통신 설계
+
+### 이유
+
+Product는 읽기 성능이 핵심이라 Cache-Aside + 이벤트 반영 혼합 전략을 사용합니다.
+
+### Redis 캐시 전략
+
+#### 핵심 키
+
+- `product:info:{productId}` (Value, TTL 24h)
+- `product:prices:{productId}` (Hash, TTL 30m)
+- `products:popular:all` (ZSet)
+- `product:detail:{productId}` (테스트 V2 경로, TTL 1h)
+
+#### 읽기 전략
+
+1. 상품 상세 조회 시 `product:info` 조회
+2. miss면 DB 조회 후 24h 캐싱
+3. 가격 Hash 조회
+4. 누락 옵션은 Trade 배치 조회로 보충 후 Hash 캐시
+
+#### 일관성 유지
+
+- Admin 수정/삭제 시 관련 키 삭제
+- Trade 가격 이벤트 수신 시 Hash 업데이트
+- Brand/Product/ProductOption 삭제는 afterCommit 이후 캐시 삭제 + 이벤트 발행
+
+### 동기 통신
+
+#### Feign
+
+- `TradeClient`
+  - 옵션별 최저가 조회/배치 조회
+- `OrderClient`
+  - 리뷰 작성 가능 여부 검증에 필요한 주문 내부 조회
+
+### 비동기 통신
+
+#### Producer (`product-events`)
+
+- `BrandDeletedEvent`
+- `ProductDeletedEvent`
+- `ProductOptionDeletedEvent`
+
+#### Consumer (`trade-events`)
+
+- `TradePriceChangedEvent`
+- 처리: `product:prices:{productId}` hash field 갱신 후 ack
+
+---
+
+## 8. 핵심 시퀀스
+
+### 상품 상세 조회 (캐시 미스 -> 가격 배치 보강)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor C as Client
+    participant P as ProductService
+    participant R as Redis
+    participant DB as ProductDB
+    participant T as TradeService
+
+    C->>P: GET /api/products/{productId}
+    P->>R: GET product:info:{productId}
+    alt cache miss
+        P->>DB: 상품/옵션 조회
+        DB-->>P: Product + Options
+        P->>R: SET product:info:{productId} (24h)
+    end
+
+    P->>R: HGETALL product:prices:{productId}
+    alt missing option prices
+        P->>T: POST /trade/internal/bids/selling/product-options/lowest-prices
+        T-->>P: 옵션별 가격
+        P->>R: HSET + EXPIRE product:prices:{productId} (30m)
+    end
+
+    P-->>C: 상품 상세 + 최저가
+```
+
+### 리뷰 생성 (Order 검증 + Snapshot 저장)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant R as ReviewService
+    participant O as OrderClient
+    participant DB as ProductDB
+
+    U->>R: POST /api/reviews (orderId, rating, content)
+    R->>R: 1주문 1리뷰 중복 확인
+    R->>O: GET /order/internal/orders/{id}/for-review
+    O-->>R: buyerId, orderStatus, 상품/옵션/브랜드 정보
+    R->>R: 상태(COMPLETED)+작성자 검증
+    R->>DB: Review + ReviewProductSnapshot 저장
+    R-->>U: 리뷰 생성 성공
+```
+
+### 브랜드 삭제 전파 (afterCommit)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor A as Admin
+    participant S as AdminBrandService
+    participant DB as ProductDB
+    participant R as Redis
+    participant K as Kafka
+    participant T as TradeService
+
+    A->>S: DELETE /api/admin/brands/{id}
+    S->>DB: 옵션 bulk soft-delete
+    S->>DB: 상품 bulk soft-delete
+    S->>DB: 브랜드 soft-delete
+    S->>S: afterCommit 훅 등록
+    S->>R: product:info/product:prices 삭제
+    S->>K: BrandDeletedEvent 발행
+    K-->>T: product-events 소비
+    T->>T: 연관 입찰 정리
+```
+
+---
+
+## 9. 디자인 패턴과 적용 이유
+
+### 이유
+
+Product는 카탈로그 CRUD + 캐시 + 이벤트 + 외부호출이 결합된 서비스라 패턴을 명시해야 리팩토링 시 설계 의도가 유지됩니다.
+
+### 패턴
+
+| 패턴                | 코드 위치                                                                                                | 적용 이유                                 |
+| :------------------ | :------------------------------------------------------------------------------------------------------- | :---------------------------------------- |
+| Cache-Aside Pattern | `ProductServiceImpl#getProductDetail/getProductOptions`                                                  | 조회 성능 향상 + DB/Trade 호출 감축       |
+| Proxy Pattern       | `@FeignClient(TradeClient, OrderClient)`                                                                 | 외부 서비스 연동 결합도 축소              |
+| Observer Pattern    | `TradeEventListener`, `ProductEventProducer`                                                             | 가격/삭제 전파를 느슨하게 연결            |
+| Snapshot Pattern    | `ReviewProductSnapshot`                                                                                  | 과거 리뷰 해석 안정성 확보                |
+| After-Commit Hook   | Admin 삭제 서비스의 `TransactionSynchronization`                                                         | 커밋 후 캐시 삭제/이벤트 발행 정합성 확보 |
+| Factory Method      | `Brand.createBrand`, `Product.createProduct`, `ProductOption.createProductOption`, `Review.createReview` | 생성 규칙/검증 일원화                     |
+| Repository Pattern  | `*Repository`                                                                                            | 도메인 로직과 영속성 분리                 |
+| Keyset Pagination   | `findByPopularityNoOffset`, `TestProductServiceImpl`                                                     | 대용량 페이지네이션 성능 실험             |
+
+---
+
+## 10. CS 관점
+
+### 핵심
+
+- Read-heavy 최적화: 캐시 + 배치 원격조회로 p99 지연 감소
+- 소유권 분리: 가격은 Trade, Product는 조회 계층으로 동작
+- 이벤트 기반 정합성: 삭제 이벤트를 비동기로 전달해 도메인 결합 감소
+- Snapshot 모델: 외부 도메인 변경에도 과거 리뷰 무결성 보장
+- No-Offset 실험: 대량 데이터 탐색에서 offset 비용 회피 가능
+
+---
+
+## 11. 보완해야 할 사항 (우선순위)
+
+### P0
+
+1. 내부/테스트 엔드포인트 노출 범위 점검
+
+- `/internal/**`, `/api/test/products/**`가 permitAll
+- 게이트웨이/네트워크 ACL 없이 직접 노출되면 공격면이 넓어질 수 있음
+
+2. 상세 조회의 write 동작 정합성
+
+- `getProductDetail`은 read 경로이지만 인기점수 DB update를 수행
+- 현재 `@Transactional(readOnly = true)`와 쓰기 쿼리 혼합 구조라 의도 명확화 필요
+
+3. 옵션 조회 예외코드 정합성
+
+- `getProductOptionForSellingBid`에서 옵션 미존재 시 `PRODUCT_NOT_FOUND`를 던짐
+- `PRODUCT_OPTION_NOT_FOUND`로 통일하는 편이 계약상 명확함
+
+### P1
+
+1. 리뷰 집계값 정합성 연결
+
+- `Product.addReviewData/deleteReviewData/updateReviewData` 메서드는 있으나 리뷰 서비스에서 직접 호출 경로가 보이지 않음
+- 리뷰 생성/수정/삭제와 `reviewCount/totalScore` 동기화 전략 명확화 필요
+
+2. 1주문 1리뷰 DB 레벨 강제
+
+- 현재는 애플리케이션 exists 체크 기반
+- 동시 요청 경쟁 상황 방지를 위해 `order_id` unique 제약 권장
+
+3. 카테고리 파싱 정책
+
+- `Category.fromNullable`은 잘못된 문자열을 `null`로 처리
+- 잘못된 카테고리 입력이 전체 조회로 흘러갈 수 있어 검증 강화 권장
+
+4. AI 호출 내결함성
+
+- `AiService`는 `block()` 기반 단순 호출
+- timeout/retry/circuit breaker/bulkhead, 응답 길이 제어, 프롬프트 길이 상한 적용 권장
+
+5. 페이지 크기 제한 일관성
+
+- 일부 API는 `PageSizeLimiter`를 사용하지만 `/api/products`는 직접 pageable 사용
+- 과도한 size 요청 방어 필요
+
+### P2
+
+1. 캐시 Stampede 방어
+
+- 인기 상품 동시 miss에서 DB/Trade 부하 가능
+- single-flight/락 기반 채움 전략 검토
+
+2. 가격 캐시 TTL 정책 보강
+
+- 이벤트 수신 시 hash 업데이트는 수행하지만 TTL 갱신 정책은 분리되어 있음
+- hot key의 만료/영속 전략을 명시적으로 통일 권장
+
+3. 이벤트 스키마 버전 관리
+
+- `product-events`/`trade-events` 확장 대비 versioned envelope 권장
+
+4. 검색 고도화
+
+- 현재 JPA 기반 검색에서 향후 전문 검색 엔진 도입 검토 가능
+
+---
+
+## 12. 운영 체크리스트
+
+### 이유
+
+Product는 사용자 트래픽과 직접 맞닿아 있어 "캐시-이벤트-외부연동" 지표를 함께 봐야 실제 원인을 빠르게 찾을 수 있습니다.
+
+### 체크 항목
+
+- Swagger: `https://dev.un-box.click/product/swagger-ui/index.html`
+- Grafana: `https://grafana.dev.un-box.click/`
+- Redis hit/miss: `product:info:*`, `product:prices:*`
+- 인기키 모니터링: `products:popular:all` 크기/증가율
+- Kafka 지표: `trade-events` consumer lag, `product-events` publish 실패율
+- Trade/Order Feign 호출 지연/오류율
+- AI 요약 API 지연/실패율/호출량
+- 관리자 삭제 API 성공률 및 이벤트 전파 성공률

--- a/docs/services/trade-service.md
+++ b/docs/services/trade-service.md
@@ -1,0 +1,546 @@
+# Trade Service Deep Dive
+
+## 1. 왜 Trade Service를 분리했는가
+
+### 이유
+
+Trade Service는 "입찰 생성/수정/취소 + 선점 + 매칭 + 가격 신호 전파"를 담당하는 고동시성 경계를 독립시키기 위해 분리되었습니다.
+
+- 같은 상품 옵션에 대해 다수 사용자가 동시에 경쟁하는 구간이라 락 전략과 상태 전이가 핵심입니다.
+- Product(User-facing 조회)와 달리, Trade는 경쟁 제어와 상태 정합성이 우선인 Write-critical 도메인입니다.
+- Order/Payment와의 연동은 많지만, 입찰 자체 상태 머신은 Trade가 단일 소유권을 가져야 합니다.
+- Redis 큐/Lua/분산락 같은 실험적 전략을 다른 서비스 영향 없이 고도화할 수 있습니다.
+
+### 역할
+
+- 판매입찰(`SellingBid`) 생성/수정/취소/조회
+- 구매입찰(`BuyingBid`) 생성/수정/취소/조회/매칭
+- 내부 API를 통한 입찰 선점/완료/복구/만료 처리
+- 옵션 단위 최저가/최고가 계산 및 캐시 제공
+- 가격 변경/매칭 이벤트를 Kafka로 발행
+- 결제/주문/상품 이벤트를 수신해 상태 반영
+
+### 비책임
+
+- 사용자 인증 원천 소유
+- 주문 상태 머신 소유
+- 결제 승인/PG 통신 소유
+- 카탈로그 원본 소유
+
+---
+
+## 2. 서비스 접근 URL
+
+### URL
+
+- Trade Swagger (dev): `https://dev.un-box.click/trade/swagger-ui/index.html`
+- Trade Swagger (local): `http://localhost:8080/trade/swagger-ui/index.html`
+- Trade API Base (dev): `https://dev.un-box.click/trade`
+- Grafana (dev): `https://grafana.dev.un-box.click/`
+
+### 참고
+
+- `application.yml` 기준 컨텍스트 경로는 `/trade`
+- Security 설정에서 ALB prefix 경로 Swagger(`/trade/**`)도 permit 처리
+
+---
+
+## 3. 아키텍처 개요
+
+### 구조
+
+- Presentation: Public/Admin/Internal/Test Controller
+- Application: 입찰 유즈케이스 서비스 + 이벤트 핸들러 + 동시성 전략
+- Domain: `SellingBid`, `BuyingBid`, Repository
+- Infrastructure: RedisTemplate/Redisson, Kafka, Feign, Spring Cache
+
+### 패키지
+
+- `trade/application/service`
+  - `SellingBidServiceImpl`
+  - `BuyingBidService`
+  - `BuyingBidInternalService`
+  - `AdminSellingBidServiceImpl`, `AdminBuyingBidServiceImpl`
+- `trade/application/service/purchase`
+  - `PessimisticPurchaseService`
+  - `DistributedPurchaseService`
+  - `DistributedNextBestPurchaseService`
+  - `CachedDistributedPurchaseService`
+  - `LuaDistributedPurchaseService`
+- `trade/application/event`
+  - `PaymentEventListener`, `OrderEventListener`, `ProductEventListener`
+  - `TradeEventProducer`
+- `trade/domain`
+  - `entity`: `SellingBid`, `BuyingBid`, `SellingStatus`, `BuyingStatus`
+  - `repository`: `SellingBidRepository`, `BuyingBidRepository`
+
+### 런타임
+
+```mermaid
+flowchart LR
+    Client -->|HTTP| TradeSvc[Trade Service]
+    TradeSvc -->|JPA| TradeDB[(Trade DB)]
+    TradeSvc -->|Redis/Redisson| Redis[(Redis)]
+    TradeSvc -->|Feign| ProductSvc[Product Service]
+    TradeSvc -->|Feign| UserSvc[User Service]
+    OrderSvc[Order Service] -->|Internal API| TradeSvc
+    PaymentSvc[Payment Service] -->|payment-events| Kafka[(Kafka)]
+    OrderSvc -->|order-events| Kafka
+    ProductSvc -->|product-events| Kafka
+    TradeSvc -->|trade-events| Kafka
+```
+
+---
+
+## 4. Spring Boot 사용 방식
+
+### 기술 매핑
+
+| 영역            | 사용 기술                                | 적용 위치                                | 사용 목적                 |
+| :-------------- | :--------------------------------------- | :--------------------------------------- | :------------------------ |
+| Web             | Spring MVC                               | `*Controller`                            | Public/Internal/Admin API |
+| Security        | Spring Security + JWT Filter             | `SecurityConfig`                         | 무상태 인증/인가          |
+| Method Security | `@EnableMethodSecurity`, `@PreAuthorize` | Admin Controller                         | 관리자 권한 제어          |
+| Persistence     | Spring Data JPA                          | `*Repository`, `*Entity`                 | 입찰 영속성               |
+| Cache           | Spring Cache + Redis                     | `@Cacheable`, `CacheManager`             | 가격/주문조회 캐시        |
+| Lock            | Redisson + AOP                           | `@DistributedLock`, `DistributedLockAop` | 선점 경쟁 제어            |
+| Messaging       | Spring Kafka                             | `*EventListener`, `TradeEventProducer`   | 상태 전파/수신            |
+| Service Call    | OpenFeign                                | `ProductClient`, `UserClient`            | 옵션/사용자 검증          |
+| Observability   | Actuator + Micrometer + OTel             | `application.yml`                        | 지표/트레이싱             |
+
+### 설정 특징
+
+- `server.servlet.context-path: /trade`
+- Kafka consumer: `group-id=trade-group`, `enable-auto-commit=false`, `StringDeserializer`
+- Caching: `@EnableCaching` 활성화
+- Feign: default `connectTimeout=1000ms`, `readTimeout=3000ms`, 일부 client는 5000ms
+- `FeignConfig`로 들어온 `Authorization` 헤더를 내부 Feign 요청으로 전달
+- `CacheWarmingRunner`가 서버 시작 시 LIVE 판매입찰을 Redis 큐(`bids:option:*`)로 적재
+
+---
+
+## 5. API 계약
+
+### Public API
+
+#### 판매입찰
+
+- `POST /trade/api/bids/selling`
+- `DELETE /trade/api/bids/selling/{sellingId}`
+- `PATCH /trade/api/bids/selling/{sellingId}/price`
+- `GET /trade/api/bids/selling/{sellingId}`
+- `GET /trade/api/bids/selling/my`
+
+#### 구매입찰
+
+- `POST /trade/api/bids/buying`
+- `DELETE /trade/api/bids/buying/{buyingBidId}`
+- `PATCH /trade/api/bids/buying/{buyingBidId}/price`
+- `GET /trade/api/bids/buying/{buyingBidId}`
+- `GET /trade/api/bids/buying/my`
+- `POST /trade/api/bids/buying/{buyingBidId}/match`
+
+#### 관리자
+
+- `GET /trade/api/admin/bids/selling`
+- `DELETE /trade/api/admin/bids/selling/{sellingId}`
+- `GET /trade/api/admin/bids/buying`
+- `DELETE /trade/api/admin/bids/buying/{buyingBidId}`
+
+#### 동시성 테스트
+
+- `POST /trade/api/trade/purchase/test?sellingBidId=...&buyerId=...&stage=stage1~stage5`
+- `POST /trade/api/trade/purchase/test/warm-up/{optionId}`
+
+### Internal API
+
+#### Selling Internal
+
+- `GET /trade/internal/bids/selling/{id}/for-cart`
+- `GET /trade/internal/bids/selling/{id}/for-order`
+- `POST /trade/internal/bids/selling/{id}/reserve`
+- `POST /trade/internal/bids/selling/{id}/sold`
+- `POST /trade/internal/bids/selling/{id}/live`
+- `GET /trade/internal/bids/selling/product-option/{productOptionId}/lowest-price`
+- `POST /trade/internal/bids/selling/product-options/lowest-prices`
+
+#### Buying Internal
+
+- `GET /trade/internal/bids/buying/{buyingBidId}/order-info`
+- `POST /trade/internal/bids/buying/{buyingBidId}/reserve`
+- `POST /trade/internal/bids/buying/{buyingBidId}/sold`
+- `POST /trade/internal/bids/buying/{buyingBidId}/expire`
+- `POST /trade/internal/bids/buying/{buyingBidId}/live`
+- `GET /trade/internal/bids/buying/product-option/{productOptionId}/highest-price`
+- `POST /trade/internal/bids/buying/product-options/highest-price`
+- `POST /trade/internal/bids/buying/{buyingBidId}/reset-match`
+
+### 보안 정책
+
+- Swagger/Actuator: permitAll
+- `/internal/**`: permitAll
+- `/api/trade/purchase/**`(동시성 테스트): permitAll
+- `/api/admin/**`: filter chain에서 `ROLE_MASTER`, `ROLE_MANAGER`만 허용
+- 그 외 API: 인증 필요
+
+---
+
+## 6. 도메인 모델과 ERD
+
+### 이유
+
+Trade는 외부 서비스 FK 결합을 최소화하고, 입찰 시점 스냅샷을 저장해 이력 해석 안정성을 확보하는 모델을 사용합니다.
+
+### 엔티티
+
+- `p_selling_bids`
+  - 판매자/상품/옵션 ID + 상품 스냅샷 + 가격/상태/마감일
+  - 핵심 인덱스: `(product_option_id, status, price)`
+- `p_buying_bids`
+  - 구매자/판매자/상품/옵션 ID + 스냅샷 + 가격/상태/매칭시각
+
+### 상태
+
+- `SellingStatus`: `LIVE`, `RESERVED`, `SOLD`, `CANCELLED`
+- `BuyingStatus`: `LIVE`, `MATCHED`, `RESERVED`, `SOLD`, `CANCELLED`, `EXPIRED`
+
+### 전이 규칙(핵심)
+
+- Selling:
+  - `LIVE -> RESERVED -> SOLD`
+  - `LIVE -> CANCELLED`(사용자 취소)
+  - `RESERVED/SOLD -> LIVE`(결제실패/환불 복구)
+  - `RESERVED -> CANCELLED`(만료/정책 취소)
+- Buying:
+  - `LIVE -> MATCHED`(판매자 수락)
+  - `MATCHED -> RESERVED -> SOLD`
+  - `MATCHED -> LIVE`(타임아웃 리셋)
+  - `LIVE -> CANCELLED`(사용자 취소)
+  - `RESERVED/SOLD -> LIVE`(결제실패/환불 복구)
+
+### ERD
+
+```mermaid
+erDiagram
+    P_SELLING_BIDS {
+      UUID selling_id PK
+      BIGINT user_id
+      UUID product_id
+      UUID product_option_id
+      DECIMAL price
+      VARCHAR status
+      DATETIME deadline
+      VARCHAR product_name
+      VARCHAR product_option_name
+      VARCHAR brand_name
+      VARCHAR model_number
+    }
+
+    P_BUYING_BIDS {
+      UUID buying_id PK
+      BIGINT buyer_id
+      BIGINT seller_id
+      UUID product_id
+      UUID product_option_id
+      DECIMAL price
+      VARCHAR status
+      DATETIME matched_at
+      DATETIME deadline
+      VARCHAR product_name
+      VARCHAR product_option_name
+      VARCHAR brand_name
+      VARCHAR model_number
+    }
+```
+
+### 모델 특징
+
+- 두 테이블 모두 soft delete(`deleted_at`) 기반
+- 타 서비스 FK 대신 ID 참조 + 스냅샷 저장
+- 상태 변경은 엔티티 메서드와 서비스 가드로 이중 검증
+
+---
+
+## 7. 캐시/통신/이벤트 설계
+
+### 이유
+
+Trade는 읽기 성능(가격/입찰 조회)과 쓰기 정합성(선점/상태전이)을 동시에 맞춰야 하므로 Cache + Event + Transaction Hook를 함께 사용합니다.
+
+### Redis 키
+
+- `bids:option:{optionId}`: 옵션별 LIVE 판매입찰 큐(가격 오름차순)
+- `bid:option:{bidId}`: bid -> option 매핑 캐시(TTL 1h, stage4/5)
+- `option:soldout:{optionId}`: 품절 게이트 캐시(TTL 10m)
+- `buying-bid:match-timeout:{buyingBidId}`: 구매입찰 매칭 타임아웃(24h)
+
+### Spring Cache
+
+- `trade:price:lowest`: 옵션별 최저가
+- `trade:price:highest`: 옵션별 최고가
+- `trade:bid:order`: 주문용 판매입찰 조회
+- `trade:bid:buying`: 주문용 구매입찰 조회
+
+### 동기 통신
+
+- `ProductClient`
+  - 판매입찰/구매입찰 생성 시 옵션 스냅샷 조회
+- `UserClient`
+  - 판매입찰 생성 시 판매자 유효성 검증
+- Feign 보조
+  - `FeignConfig`가 `Authorization` 헤더 전달
+
+### 비동기 통신
+
+#### Producer (`trade-events`)
+
+- `TradePriceChangedEvent`
+- `BuyingBidMatchedEvent`
+
+#### Consumer
+
+- `payment-events`
+  - `PaymentCompleted` -> 입찰 `SOLD`
+  - `PaymentFailed` -> 입찰 `LIVE` 복구
+- `order-events`
+  - `OrderCancelled`, `OrderExpired`, `OrderRefundRequested`, `OrderShipmentExpired`
+  - 주문 이벤트에 따라 `LIVE/CANCELLED/SOLD` 복구/변경
+- `product-events`
+  - Brand/Product/Option 삭제 이벤트 수신 시 연관 입찰 soft-delete 처리
+
+### 정합성 패턴
+
+- `TransactionSynchronization.afterCommit`로 이벤트 발행 시점 고정
+- 상태가 이미 터미널이면 스킵하는 멱등 가드 다수 적용
+- Kafka listener는 수동 ack 정책 사용
+
+---
+
+## 8. 동시성 제어 (stage1~stage5)
+
+### 전략 요약
+
+| Stage  | 구현체                               | 제어 방식                           | 장점                         | 한계                             |
+| :----- | :----------------------------------- | :---------------------------------- | :--------------------------- | :------------------------------- |
+| stage1 | `PessimisticPurchaseService`         | DB 비관적 락(`FOR UPDATE`)          | 구현 단순, 강한 일관성       | DB 락 대기 증가                  |
+| stage2 | `DistributedPurchaseService`         | Bid 단위 Redisson 락(Fail-fast)     | DB 락 경합 분산              | 단일 bid 기준이라 차선 매칭 없음 |
+| stage3 | `DistributedNextBestPurchaseService` | Option 단위 락 + 최저 LIVE 재조회   | 차선 매칭 가능               | 락 범위가 넓어 대기 증가 가능    |
+| stage4 | `CachedDistributedPurchaseService`   | Sold-out 캐시 + Option 락 + DB 확인 | DB 접근 절감, 품절 빠른 차단 | 캐시 정확도/만료 전략 관리 필요  |
+| stage5 | `LuaDistributedPurchaseService`      | Redis `LPOP` 원자 선점 + DB 반영    | 락 없이 초저지연             | DB 실패 시 큐 보상 정책 필요     |
+
+### 공통 트랜잭션
+
+- `PurchaseTransactionService#decreaseStock`는 `REQUIRES_NEW`
+- 최종 반영 직전에 `LIVE` 상태를 재검증하고 `SOLD`로 전이
+
+### 전략 선택 기준
+
+- 정확성 최우선/트래픽 낮음: stage1
+- 분산 환경 기본형: stage2
+- 동일 옵션 경쟁 높고 차선 매칭 필요: stage3
+- 핫옵션 품절 구간 최적화: stage4
+- 대량 동접 초저지연 실험: stage5
+
+---
+
+## 9. 핵심 시퀀스
+
+### 판매입찰 주문-결제 완료
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant O as Order Service
+    participant T as Trade Service
+    participant P as Payment Service
+    participant K as Kafka
+
+    U->>O: 주문 생성 요청(sellingBidId)
+    O->>T: reserveSellingBid(LIVE->RESERVED)
+    O-->>U: orderId 반환
+
+    U->>P: 결제 승인 요청
+    P->>K: PaymentCompleted 발행
+    K-->>T: payment-events 전달
+    T->>T: soldSellingBid(RESERVED->SOLD)
+    T->>K: TradePriceChangedEvent 발행
+```
+
+### 구매입찰 매칭 + 타임아웃 복구
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor S as Seller
+    participant T as Trade Service
+    participant R as Redis
+    participant K as Kafka
+    participant U as User Service(Notification)
+    participant O as Order Service
+
+    S->>T: matchBuyingBid(buyingBidId)
+    T->>T: LIVE->MATCHED + matchedAt 저장
+    T->>R: SET buying-bid:match-timeout:{id} TTL 24h
+    T->>K: BuyingBidMatchedEvent 발행
+    K-->>U: 알림 발송
+
+    alt 24시간 내 주문 생성
+        O->>T: reserveBuyingBid(MATCHED->RESERVED)
+        O->>R: DEL buying-bid:match-timeout:{id}
+    else 타임아웃
+        R-->>O: key expired 이벤트
+        O->>T: resetMatchedBid(MATCHED->LIVE)
+    end
+```
+
+### Stage5 Lua 큐 기반 선점
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor B as Buyer
+    participant C as TestPurchaseController
+    participant L as LuaDistributedPurchaseService
+    participant R as Redis
+    participant TX as PurchaseTransactionService
+    participant DB as Trade DB
+
+    B->>C: purchase(stage5, requestBidId)
+    C->>L: purchase(requestBidId, buyerId)
+    L->>R: LPOP bids:option:{optionId}
+    alt queue empty
+        R-->>L: nil
+        L-->>B: BID_ALREADY_MATCHED
+    else matchedBidId 반환
+        R-->>L: matchedBidId
+        L->>TX: decreaseStock(matchedBidId)
+        TX->>DB: LIVE 확인 후 SOLD 반영
+        TX-->>B: 성공
+    end
+```
+
+---
+
+## 10. 디자인 패턴과 적용 이유
+
+### 패턴
+
+| 패턴                   | 코드 위치                                     | 적용 이유                       |
+| :--------------------- | :-------------------------------------------- | :------------------------------ |
+| Strategy Pattern       | `purchase/*PurchaseService`                   | stage별 동시성 전략 교체/실험   |
+| Proxy Pattern          | `@FeignClient`, Spring Security Filter        | 외부 호출/보안 경계 캡슐화      |
+| Decorator(AOP) Pattern | `@DistributedLock` + `DistributedLockAop`     | 비즈니스 로직 오염 없이 락 부여 |
+| Repository Pattern     | `SellingBidRepository`, `BuyingBidRepository` | 도메인과 영속성 분리            |
+| Observer Pattern       | Kafka Producer/Listener                       | 서비스 간 느슨한 결합           |
+| Cache-Aside Pattern    | `@Cacheable` + 명시적 evict                   | 읽기 성능 향상                  |
+| After-Commit Hook      | `TransactionSynchronization`                  | 커밋 후 이벤트 발행 정합성      |
+| Snapshot Pattern       | 입찰 내 상품/옵션/브랜드 이름 저장            | 타 서비스 변경에도 이력 안정성  |
+| Idempotency Guard      | SOLD/CANCELLED 상태 스킵 로직                 | 재시도/중복 이벤트 안정성       |
+| Builder Pattern        | Entity/DTO Builder                            | 생성 인자 가독성 및 안전성      |
+
+---
+
+## 11. CS 관점
+
+### 핵심
+
+- Lock Granularity
+  - bid 단위 락은 충돌 범위가 작고,
+  - option 단위 락은 차선 매칭 정확도가 높습니다.
+- Fail-fast vs Wait
+  - stage2/4는 fail-fast로 응답성을 우선하고,
+  - stage3는 대기를 허용해 성공률을 높입니다.
+- 상태 전이 정합성
+  - 단순 CRUD가 아니라 상태 머신으로 봐야 하며,
+  - 전이 가드가 재처리 안정성의 핵심입니다.
+- Eventual Consistency
+  - 결제/주문/상품 이벤트는 비동기 반영이므로 일시적 불일치를 허용합니다.
+- Cache Coherency
+  - 캐시 무효화와 이벤트 발행 순서가 잘못되면 stale read가 생기므로 afterCommit 패턴이 중요합니다.
+- Hot Key/Queue 문제
+  - 인기 옵션은 `bids:option:{optionId}`가 집중될 수 있어 키 분산/메트릭 관측이 필요합니다.
+
+---
+
+## 12. 보완해야 할 사항 (우선순위)
+
+### P0
+
+1. Product 이벤트 소비 타입 정합성 점검
+
+- 현재 Trade consumer는 `StringDeserializer` 설정인데, `ProductEventListener`는 `ConsumerRecord<String, Object>` + `instanceof` 분기를 사용합니다.
+- 실제 런타임 역직렬화 타입과 분기 로직이 불일치하면 상품 삭제 이벤트가 무시될 수 있습니다.
+
+2. 상품 삭제 시 BuyingBid 정리 경로 누락
+
+- `ProductEventListener`는 현재 `AdminSellingBidService`만 호출해 판매입찰만 정리합니다.
+- 구매입찰(`AdminBuyingBidService`) 정리가 빠지면 삭제된 옵션에 LIVE 구매입찰이 남을 수 있습니다.
+
+3. 내부/테스트 API 접근 제어 강화
+
+- `/internal/**`, `/api/trade/purchase/**`가 permitAll입니다.
+- 게이트웨이/네트워크 ACL 없이 직접 노출되면 공격면이 커집니다.
+
+### P1
+
+1. 관리자 권한 정책 일관성
+
+- `SecurityConfig`는 `/api/admin/**`를 `MASTER/MANAGER`만 허용합니다.
+- 일부 컨트롤러는 `@PreAuthorize`에서 `INSPECTOR` 조회 권한을 명시해 정책이 충돌합니다.
+
+2. 가격 이벤트 의미 분리
+
+- `BuyingBidService`에 `TradePriceChangedEvent`를 최고가에도 재사용하는 TODO가 남아 있습니다.
+- 하위 소비자가 "최저가 이벤트"로 가정하면 해석 충돌 위험이 있습니다.
+
+3. Stage5 실패 보상
+
+- Lua `LPOP` 후 DB 반영 실패 시 큐 재적재/보상 트랜잭션이 없습니다.
+- 고가용성 환경에서 일시 장애 시 유실처럼 보이는 케이스를 만들 수 있습니다.
+
+4. 큐 재구성 비용 최적화
+
+- `addBidToRedisQueue`는 변경마다 옵션 큐를 삭제 후 전체 rebuild합니다.
+- 핫옵션/대량 입찰에서는 Redis/DB 모두에 비용이 큽니다.
+
+5. 이벤트 중복 처리 고도화
+
+- 현재는 상태 가드 중심 멱등성입니다.
+- 이벤트 ID 저장 기반 dedupe를 추가하면 재처리 안정성이 더 높아집니다.
+
+### P2
+
+1. 상태 머신 명시화
+
+- 전이 규칙이 서비스/리스너에 분산되어 있어 정책 변경 시 영향 파악 비용이 큽니다.
+
+2. 동시성/큐 지표 강화
+
+- stage별 처리량, 락 획득 실패율, 큐 길이, 상태전이 실패율 메트릭이 필요합니다.
+
+3. 동시성 테스트 API 운영 분리
+
+- 테스트 컨트롤러는 유용하지만 운영 프로파일에서 비활성화 또는 별도 서비스 분리가 안전합니다.
+
+---
+
+## 13. 운영 체크리스트
+
+### 체크 항목
+
+- Swagger: `https://dev.un-box.click/trade/swagger-ui/index.html`
+- Grafana: `https://grafana.dev.un-box.click/`
+- Kafka:
+  - `trade-events` publish 실패율
+  - `payment-events`, `order-events`, `product-events` consumer lag
+- Redis:
+  - `bids:option:*` 큐 길이 분포
+  - `option:soldout:*` 키 개수/만료 패턴
+  - `buying-bid:match-timeout:*` 만료 처리량
+- API 오류:
+  - `INVALID_ORDER_STATUS`, `BID_ALREADY_MATCHED` 비율
+  - `LockAcquisitionFailedException` 발생 추이
+- 성능:
+  - stage별 구매 처리 지연(p95/p99)
+  - Feign(Product/User) 지연 및 오류율

--- a/docs/services/user-service.md
+++ b/docs/services/user-service.md
@@ -1,0 +1,510 @@
+# User Service Deep Dive
+
+## 1. 왜 User Service를 분리했는가
+
+### 이유
+
+User Service는 "인증/인가 + 사용자 정체성 + 사용자 자산(프로필/주소/계좌/장바구니)"을 한 경계 안에서 관리하기 위해 분리되었습니다.
+
+- 인증은 거래/결제보다 보안 변경 주기가 빠르고 장애 영향도가 큼
+- 사용자 원천 데이터(이메일, 닉네임, 권한)는 모든 서비스가 참조하므로 단일 소유자가 필요
+- 인증 장애와 거래 장애를 분리해 Blast Radius를 최소화해야 함
+- User/Admin 권한 모델과 운영 정책은 주문/결제 도메인과 독립적으로 발전해야 함
+
+### 역할
+
+- JWT 기반 로그인/로그아웃/재발급
+- 사용자/관리자 계정 관리
+- 사용자 배송지/정산 계좌 관리
+- 장바구니 관리
+- 상품 요청(Product Request) 접수 및 관리자 처리
+- Trade 이벤트 기반 사용자 알림(이메일)
+- 다른 서비스가 호출하는 내부 사용자 정보 API 제공
+
+### 비책임
+
+- 상품 카탈로그 소유권
+- 입찰 매칭/가격 소유권
+- 주문 상태 머신
+- 결제 승인/환불/정산 확정
+
+---
+
+## 2. 서비스 접근 URL
+
+### URL
+
+- User Swagger (dev): `https://dev.un-box.click/user/swagger-ui/index.html`
+- User Swagger (local): `http://localhost:8080/user/swagger-ui/index.html`
+- User API Base (dev): `https://dev.un-box.click/user`
+- Grafana (dev): `https://grafana.dev.un-box.click/`
+
+### 참고
+
+- `application.yml` 기준 컨텍스트 경로는 `/user`
+- 실제 엔드포인트는 `/{context-path}` + 컨트롤러 매핑으로 구성됨
+
+---
+
+## 3. 아키텍처 개요
+
+### 구조
+
+- Presentation: Controller + OpenAPI Interface
+- Application: 유즈케이스 단위 Service
+- Domain: Entity + Repository
+- Infrastructure: Security Filter Chain, Redis, Kafka Consumer, Feign Client, Mail Sender
+
+### 패키지
+
+- `auth`: 인증 진입점, 재발급, 테스트 부트스트랩
+- `common/security`: 로그인/로그아웃 필터, 사용자 로드, 리프레시 토큰 저장소
+- `user`: 사용자 정보, 주소/계좌, 내부 API
+- `admin`: 관리자 스태프 도메인
+- `cart`: 장바구니 도메인
+- `request`: 상품 요청 도메인
+- `notification`: 이벤트 소비/메일 알림
+
+### 런타임
+
+```mermaid
+flowchart LR
+    Client -->|HTTP| UserSvc[User Service]
+    UserSvc -->|JPA| UserDB[(User DB)]
+    UserSvc -->|Redis| Redis[(Redis)]
+    UserSvc -->|Feign| TradeSvc[Trade Service]
+    TradeSvc -->|trade-events| Kafka[(Kafka)]
+    Kafka -->|consume| UserSvc
+    UserSvc -->|SMTP| Mail[(Mail Provider)]
+```
+
+---
+
+## 4. Spring Boot 사용 방식
+
+### 기술 매핑
+
+| 영역               | 사용 기술                    | 적용 위치                                    | 사용 목적                |
+| :----------------- | :--------------------------- | :------------------------------------------- | :----------------------- |
+| Web                | Spring MVC                   | `*Controller`                                | REST API 노출            |
+| Validation         | Jakarta Validation           | Request DTO                                  | 입력 검증                |
+| Security           | Spring Security              | `SecurityConfig`, `LoginFilter`, `JwtFilter` | 인증/인가                |
+| Persistence        | Spring Data JPA              | `*Repository`, `*Entity`                     | 영속성                   |
+| Redis              | Spring Data Redis            | `RefreshTokenRedisRepository`, `JwtUtil`     | 리프레시 토큰/블랙리스트 |
+| Messaging          | Spring Kafka                 | `NotificationEventListener`                  | 비동기 이벤트 소비       |
+| Service-to-service | OpenFeign                    | `TradeClient`                                | 내부 API 동기 호출       |
+| Mail               | JavaMailSender               | `NotificationService`                        | 이메일 알림              |
+| Docs               | springdoc-openapi            | Swagger UI                                   | API 문서                 |
+| Observability      | Actuator + Micrometer + OTel | `application.yml`                            | 메트릭/트레이싱          |
+
+### 설정 특징
+
+- `server.servlet.context-path: /user`
+- JWT 만료: Access 1시간, Refresh 60시간
+- Kafka consumer: `enable-auto-commit: false`, `ack-mode: manual`
+- Redis key prefix: `refresh:`, `blacklist:`
+
+---
+
+## 5. API 계약
+
+### Public API
+
+#### 인증
+
+- `POST /user/api/auth/signup`
+- `POST /user/api/auth/login`
+- `POST /user/api/auth/logout`
+- `POST /user/api/auth/reissue`
+- `POST /user/api/admin/auth/signup`
+- `POST /user/api/admin/auth/login`
+- `POST /user/api/admin/auth/logout`
+- `POST /user/api/admin/auth/reissue`
+
+#### 사용자
+
+- `GET /user/api/users/me`
+- `PATCH /user/api/users/me`
+- `DELETE /user/api/users/me`
+
+#### 주소/계좌
+
+- `POST /user/users/me/addresses`
+- `GET /user/users/me/addresses`
+- `DELETE /user/users/me/addresses/{addressId}`
+- `POST /user/users/me/accounts`
+- `GET /user/users/me/accounts`
+- `DELETE /user/users/me/accounts/{accountId}`
+
+#### 장바구니
+
+- `POST /user/api/carts`
+- `GET /user/api/carts`
+- `DELETE /user/api/carts/{id}`
+- `DELETE /user/api/carts`
+
+#### 상품 요청
+
+- `POST /user/api/products/requests`
+- `GET /user/api/admin/product-requests`
+- `PATCH /user/api/admin/product-requests/{productRequestId}/status`
+
+#### 관리자
+
+- `GET /user/api/admin/staff`
+- `GET /user/api/admin/staff/managers`
+- `GET /user/api/admin/staff/inspectors`
+- `GET /user/api/admin/staff/{adminId}`
+- `PATCH /user/api/admin/staff/{adminId}`
+- `DELETE /user/api/admin/staff/{adminId}`
+- `GET /user/api/admin/users`
+- `PATCH /user/api/admin/users/{userId}`
+- `DELETE /user/api/admin/users/{userId}`
+
+### Internal API
+
+- `GET /user/internal/users/{userId}/for-selling-bid`
+- `GET /user/internal/users/{userId}/for-order`
+- `GET /user/internal/users/{userId}/has-default-account`
+
+### 경계 규칙
+
+- 로그인 실제 처리는 Controller가 아니라 `LoginFilter`가 수행
+- 내부 API는 최소 필드 계약만 반환해 결합도를 낮춤
+
+---
+
+## 6. 인증/인가 상세
+
+### 인증 파이프라인
+
+1. `LoginFilter`가 `/api/auth/login`, `/api/admin/auth/login` 요청을 처리
+2. `AuthenticationManager` + `CustomUserDetailsService`로 사용자 검증
+3. Access/Refresh JWT 발급
+4. `refresh:{email}` 키로 Redis 저장
+5. Access는 `Authorization` 헤더, Refresh는 HttpOnly Cookie로 전달
+6. 이후 요청에서 `JwtFilter`가 만료/블랙리스트/클레임 검증
+7. SecurityContext에 `CustomUserDetails` 주입
+
+### 권한 모델
+
+- 사용자: `ROLE_USER`
+- 관리자: `ROLE_MASTER`, `ROLE_MANAGER`, `ROLE_INSPECTOR`
+- URL 규칙 + 서비스 메서드 `@PreAuthorize` 혼합 적용
+
+### Redis 키 설계
+
+- `refresh:{email}`
+- 용도: 현재 유효한 Refresh Token 저장
+- TTL: `REFRESH_TOKEN_EXPIRE_MS` (60시간)
+- `blacklist:{accessToken}`
+- 용도: 로그아웃된 Access Token 강제 무효화
+- TTL: Access 만료시간 기준
+
+### 토큰 라이프사이클 시퀀스
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor C as Client
+    participant LF as LoginFilter
+    participant AS as AuthManager/UserDetailsService
+    participant JU as JwtUtil
+    participant R as Redis
+
+    C->>LF: POST /api/auth/login
+    LF->>AS: authenticate(email, password)
+    AS-->>LF: principal(role, id)
+    LF->>JU: create access + refresh
+    LF->>R: SET refresh:{email} = refreshToken (TTL)
+    LF-->>C: Authorization: Bearer access + refresh cookie
+```
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor C as Client
+    participant RF as Reissue Controller
+    participant JU as JwtUtil
+    participant R as Redis
+
+    C->>RF: POST /api/auth/reissue
+    RF->>RF: refresh 추출(cookie/header/param)
+    RF->>JU: 만료/클레임 검증
+    RF->>R: refresh 저장 갱신
+    RF-->>C: 새 access + 새 refresh
+```
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor C as Client
+    participant LO as CustomLogoutFilter
+    participant JU as JwtUtil
+    participant R as Redis
+
+    C->>LO: POST /api/auth/logout
+    LO->>JU: access token 파싱(email)
+    LO->>R: DEL refresh:{email}
+    LO->>JU: blacklist:{accessToken} 등록
+    LO-->>C: logout success
+```
+
+---
+
+## 7. 도메인 모델과 ERD
+
+### 엔티티
+
+- `p_users`: 사용자 기본 정보
+- `p_admin`: 관리자 계정/역할/상태
+- `p_address`: 사용자 배송지 (`ManyToOne -> User`)
+- `p_account`: 정산 계좌 (`user_id` 값 참조)
+- `p_cart`: 판매입찰 참조 + 상품 스냅샷
+- `p_product_requests`: 사용자 상품 요청
+
+### 공통 규칙
+
+- 대부분 `BaseEntity` 상속 (`created_at`, `updated_at`, `deleted_at` 등)
+- 대부분 `@SQLRestriction("deleted_at IS NULL")`로 soft-delete 기본 필터링
+- ID 타입 혼합: `Long`(User/Admin), `UUID`(Address/Account/Cart/ProductRequest)
+
+### ERD
+
+```mermaid
+erDiagram
+    P_USERS {
+      BIGINT id PK
+      VARCHAR email UK
+      VARCHAR nickname UK
+      VARCHAR phone
+      DATETIME deleted_at
+    }
+
+    P_ADMIN {
+      BIGINT id PK
+      VARCHAR email UK
+      VARCHAR nickname UK
+      VARCHAR admin_role
+      VARCHAR admin_status
+      DATETIME deleted_at
+    }
+
+    P_ADDRESS {
+      UUID id PK
+      BIGINT user_id FK
+      VARCHAR receiver_name
+      VARCHAR address
+      VARCHAR detail_address
+      VARCHAR zip_code
+      BOOLEAN is_default
+      DATETIME deleted_at
+    }
+
+    P_ACCOUNT {
+      UUID account_id PK
+      BIGINT user_id
+      VARCHAR bank_name
+      VARCHAR account_number
+      VARCHAR account_holder
+      BOOLEAN is_default
+      DATETIME deleted_at
+    }
+
+    P_CART {
+      UUID id PK
+      BIGINT user_id FK
+      UUID selling_bid_id
+      UUID product_id
+      UUID product_option_id
+      VARCHAR product_name
+      VARCHAR product_option_name
+      VARCHAR model_number
+      DATETIME deleted_at
+    }
+
+    P_PRODUCT_REQUESTS {
+      UUID product_request_id PK
+      BIGINT user_id
+      VARCHAR name
+      VARCHAR brand_name
+      VARCHAR status
+      DATETIME deleted_at
+    }
+
+    P_USERS ||--o{ P_ADDRESS : has
+    P_USERS ||--o{ P_CART : has
+```
+
+### 불변 조건
+
+- 주소 등록: 첫 주소 자동 기본값, 기본 주소 신규 등록 시 기존 기본값 해제
+- 계좌 등록: 첫 계좌 자동 기본값, 기본 계좌 신규 등록 시 기존 기본값 해제
+- 장바구니: 본인 판매입찰 등록 불가, LIVE 상태만 등록 가능, 동일 판매입찰 중복 불가
+
+---
+
+## 8. 서비스 간 통신과 일관성
+
+### 동기 통신
+
+- 대상: Trade Service
+- 클라이언트: `TradeClient`
+- 호출: `/trade/internal/bids/selling/{id}/for-cart`
+- 목적: 장바구니 생성/조회 시 판매입찰 상태/가격 확인
+
+### 비동기 통신
+
+- 토픽: `trade-events`
+- 이벤트: `BuyingBidMatchedEvent`
+- 소비자: `NotificationEventListener`
+- 목적: 구매입찰 매칭 시 사용자 알림 전송
+
+### 일관성 모델
+
+- 인증/인가: 요청 시점 강한 일관성(토큰 만료/블랙리스트 즉시 검증)
+- 장바구니: Trade 내부 상태를 동기 조회해 정합성 검증
+- 알림: Eventual Consistency 허용(실패 시 비즈니스 트랜잭션과 분리)
+
+### 시퀀스: 장바구니 등록
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant C as CartController
+    participant S as CartService
+    participant T as TradeClient
+    participant DB as UserDB
+
+    U->>C: POST /api/carts(sellingBidId)
+    C->>S: createCart(userId, request)
+    S->>T: getSellingBidForCart(sellingBidId)
+    T-->>S: selling status + snapshot data
+    S->>S: 상태/LIVE + 본인상품 + 중복검증
+    S->>DB: cart 저장
+    S-->>U: cart created
+```
+
+### 시퀀스: 매칭 알림
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as Trade Service
+    participant K as Kafka
+    participant L as NotificationEventListener
+    participant N as NotificationService
+    participant M as Mail Sender
+
+    T->>K: BuyingBidMatchedEvent 발행
+    K-->>L: 이벤트 전달
+    L->>N: sendNotification(buyerId,...)
+    N->>M: 이메일 전송 시도
+    M-->>N: 성공 또는 실패
+```
+
+---
+
+## 9. 디자인 패턴과 적용 이유
+
+### 패턴
+
+| 패턴                | 코드 위치                                                                     | 적용 이유                                  |
+| :------------------ | :---------------------------------------------------------------------------- | :----------------------------------------- |
+| Proxy Pattern       | `@FeignClient`, Security Filter Chain                                         | 외부 호출/보안 처리의 경계 캡슐화          |
+| Builder Pattern     | `Cart`, `Account`, DTO Builder                                                | 생성 인자 증가에 대한 가독성 확보          |
+| Factory Method      | `User.createUser`, `Admin.createAdmin`, `ProductRequest.createProductRequest` | 생성 규칙/검증을 단일 진입점으로 통일      |
+| Repository Pattern  | `*Repository`                                                                 | 도메인 로직과 영속성 분리                  |
+| Observer Pattern    | `@KafkaListener`                                                              | 거래 이벤트와 알림 도메인 느슨한 결합      |
+| Soft Delete Pattern | `BaseEntity#softDelete` + `@SQLRestriction`                                   | 삭제 이력 보존 및 운영 복구 여지 확보      |
+| Snapshot Pattern    | `Cart`의 상품 필드                                                            | 타 서비스 데이터 변경에도 조회 안정성 유지 |
+| Guard Clause        | 서비스 내 빠른 예외 반환                                                      | 실패 케이스를 앞에서 차단해 흐름 단순화    |
+
+---
+
+## 10. CS 관점
+
+### 핵심
+
+- Stateless JWT: 서버 세션 제거로 수평 확장에 유리
+- Token Revocation: JWT 즉시 폐기 불가 문제를 Redis 블랙리스트로 보완
+- Bounded Context: User가 정체성 원천 데이터 소유, Trade/Order는 내부 API로 소비
+- Sync + Async Hybrid: 검증은 동기, 알림은 비동기로 분리해 응답시간과 신뢰성 균형 확보
+- Soft Delete 중심 모델: 감사 추적과 운영 복구에 유리
+- Snapshot Read Model: 장바구니 조회 성능과 내결함성 확보
+
+---
+
+## 11. 보완해야 할 사항 (우선순위)
+
+### P0
+
+1. Method Security 활성화 확인 필요
+
+- `@PreAuthorize`가 다수 존재하나 `@EnableMethodSecurity` 설정이 User 서비스에서 확인되지 않음
+- 의도한 서비스 메서드 권한 검사가 실제로 동작하는지 즉시 검증 필요
+
+2. 관리자 로그아웃 경로 정합성
+
+- Security 규칙은 `/api/admin/auth/logout`을 허용하지만 `CustomLogoutFilter`는 `/api/auth/logout`만 처리
+- 관리자 로그아웃이 동일 정책으로 무효화되는지 점검 필요
+
+3. 로그아웃 블랙리스트 TTL 계산 검증
+
+- 로그아웃 필터의 `expirationMillis = 60 * 60 * 24L`는 밀리초 기준 약 86.4초
+- Access 만료(1시간) 대비 너무 짧아 재사용 위험 가능
+
+### P1
+
+1. 재발급 검증 정책 통일
+
+- 관리자 재발급은 Redis 토큰 일치 검증을 수행
+- 사용자 재발급은 동일 검증이 상대적으로 약함
+- 사용자/관리자 동일한 재발급 보안 규칙으로 통일 권장
+
+2. 관리자 재발급 토큰 생성 경로 점검
+
+- 관리자 재발급에서 user claim/토큰 생성 메서드 사용 코드가 보여 정책 정합성 점검 필요
+
+3. Kafka 수동 커밋 설정 점검
+
+- 설정은 `ack-mode: manual`이나 Listener에서 `Acknowledgment` 사용 코드가 없음
+- 오프셋 커밋 정책 의도와 실제 동작 일치 여부 점검 필요
+
+4. 보안 로그 마스킹
+
+- 토큰 전체 문자열이 로그에 남는 구간이 있어 민감정보 노출 위험
+- 토큰/개인정보 로그 마스킹 정책 필요
+
+### P2
+
+1. API 경로 일관성
+
+- 사용자 API 대부분은 `/api/*` 패턴
+- 주소/계좌는 `/users/me/*` 패턴으로 분리되어 게이트웨이 정책 복잡도 증가
+
+2. 환경 설정 안정화
+
+- `ddl-auto: create`가 운영 환경에서 유지되면 위험
+- 프로파일별 스키마 관리 전략(Flyway/Liquibase 등) 권장
+
+3. 알림 채널 확장성
+
+- 현재 이메일 중심, `JavaMailSender` 미설정 시 skip
+- 큐잉/재시도/대체 채널(SMS/Push) 설계 여지 존재
+
+---
+
+## 12. 운영 체크리스트
+
+### 체크 항목
+
+- Swagger 접근 확인: `https://dev.un-box.click/user/swagger-ui/index.html`
+- Grafana 대시보드 확인: `https://grafana.dev.un-box.click/`
+- 인증 실패율: `401/403` 비율, 급증 시점
+- Redis 키 모니터링: `refresh:*`, `blacklist:*` 개수/증가율/메모리
+- Kafka 모니터링: `trade-events` consumer lag
+- 재발급 API 비율/실패율 모니터링
+- 관리자 API 감사 로그(변경/삭제) 추적
+- Actuator `health`, `prometheus` 수집 상태 확인


### PR DESCRIPTION
- Introduced comprehensive markdown files for Trade Service and User Service.
- Documented the rationale for service separation, roles, responsibilities, architecture overview, API contracts, and design patterns.
- Included runtime diagrams, ERD, and consistency models for both services.
- Highlighted security policies, caching strategies, and operational checklists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 서비스별 심화 문서 섹션 추가 (User, Product, Trade, Order, Payment 서비스)
  * 각 서비스별 아키텍처, API 계약, 도메인 모델, 운영 가이드를 포함한 종합 문서 제공
  * README에 문서 색인 추가로 접근성 개선

* **Chores**
  * 빌드 구성 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->